### PR TITLE
Move `openedTopClass` to `rootClasses()`

### DIFF
--- a/packages/oruga/src/components/autocomplete/Autocomplete.vue
+++ b/packages/oruga/src/components/autocomplete/Autocomplete.vue
@@ -182,13 +182,13 @@ export default {
         rootClasses() {
             return [
                 this.computedClass('autocomplete', 'rootClass', 'o-autocomplete'),
-                { [this.computedClass('autocomplete', 'expandedClass', 'o-autocomplete-expanded')]: this.expanded }
+                { [this.computedClass('autocomplete', 'expandedClass', 'o-autocomplete-expanded')]: this.expanded },
+                { [this.computedClass('autocomplete', 'openedTopClass', 'o-autocomplete-opened-top')]: (this.isOpenedTop && !this.appendToBody)  }
             ]
         },
         menuClasses() {
             return [
-                this.computedClass('autocomplete', 'menuClass', 'o-autocomplete-menu'),
-                { [this.computedClass('autocomplete', 'openedTopClass', 'o-autocomplete-opened-top')]: (this.isOpenedTop && !this.appendToBody)  }
+                this.computedClass('autocomplete', 'menuClass', 'o-autocomplete-menu')
             ]
         },
         itemClasses() {

--- a/packages/oruga/src/scss/components/_autocomplete.scss
+++ b/packages/oruga/src/scss/components/_autocomplete.scss
@@ -33,10 +33,7 @@ $autocomplete-menu-zindex : 20 !default;
         @include variable('padding', 'autocomplete-menu-padding', $autocomplete-menu-padding);
         @include variable('margin', 'autocomplete-menu-margin', $autocomplete-menu-margin);
         @include variable('max-height', 'autocomplete-menu-max-height', $autocomplete-menu-max-height);
-        &.o-autocomplete-opened-top {
-            top: auto;
-            bottom: 100%;
-        }
+        
         .o-autocomplete-item {
             display: block;
             position: relative;
@@ -59,6 +56,10 @@ $autocomplete-menu-zindex : 20 !default;
                 text-decoration: none;
             }
         }
+    }
+    &.o-autocomplete-opened-top .o-autocomplete-menu {
+        top: auto;
+        bottom: 100%;
     }
     &.o-autocomplete-expanded {
         width: 100%;


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

## Proposed Changes

This allows the input to be styled differently depending on the direction of the dropdown. Ex: input border radius can adjust depending on if the dropdown is showing above or below the input.
