### PR TITLE
fix(table): typo in sandbox docs

### DIFF
--- a/packages/docs/components/Table.md
+++ b/packages/docs/components/Table.md
@@ -65,7 +65,7 @@ title: Table
 
 :::
 
-### Sandobx
+### Sandbox
 
 ::: demo
 


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes typo in Table docs :)


