### PR TITLE
Select class prop in docs

### DIFF
--- a/packages/docs/components/Select.md
+++ b/packages/docs/components/Select.md
@@ -233,7 +233,7 @@ export default {
                 },
                 {
                     class: "selectClass",
-                    description: "Class of the native select element",
+                    description: "Class of the native select element"
                 },
                 {
                     class: "sizeClass",

--- a/packages/docs/components/Select.md
+++ b/packages/docs/components/Select.md
@@ -232,6 +232,10 @@ export default {
                     }
                 },
                 {
+                    class: "selectClass",
+                    description: "Class of the native select element",
+                },
+                {
                     class: "sizeClass",
                     description: "Class of the select size",
                     properties: ["size"],


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

This PR adds `selectClass` prop to the **Select** component section in the docs, looks like it was missing. 

If I overlooked something, please feel free to ignore this PR.