### PR TITLE
add scroll-x in _tabs.scss

### DIFF
--- a/packages/oruga/src/scss/components/_tabs.scss
+++ b/packages/oruga/src/scss/components/_tabs.scss
@@ -111,6 +111,18 @@ $tabs-toggle-link-active-color: $primary-invert !default;
         flex-grow: 1;
         flex-shrink: 0;
         justify-content: flex-start;
+        overflow-x: auto;
+        // padding bottom to keep showing the border-bottom
+        padding-bottom: $tabs-border-bottom-width;
+        scroll-behavior: smooth;
+        -webkit-overflow-scrolling: touch;
+
+        // to hide scrollbar
+        &::-webkit-scrollbar {
+            display: none;
+            -webkit-appearance: none;
+        }
+
         @include avariable('font-size', 'tabs-font-size', $tabs-font-size);
         @each $name, $value in $sizes {
             &--#{$name} {


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->
Fixes #112 
## Proposed Changes

- add `overflow-x: auto`
- add `padding-bottom: $tabs-border-bottom-width` to keep showing the border-bottom
- hide the scrollbar
