### PR TITLE
Update Table.vue to remove Vue warn message

### DIFF
--- a/packages/oruga-next/src/components/table/Table.vue
+++ b/packages/oruga-next/src/components/table/Table.vue
@@ -328,7 +328,7 @@ export default defineComponent({
         'check', 'check-all', 'update:checkedRows',
         'select', 'update:selected', 'filters-change', 'details-close', 'update:openedDetailed',
         'mouseenter', 'mouseleave', 'sort', 'sorting-priority-removed',
-        'dragstart', 'dragend', 'drop', 'dragleave', 'dragover'
+        'dragstart', 'dragend', 'drop', 'dragleave', 'dragover', 'cell-click'
     ],
     props: {
         /** Table data */


### PR DESCRIPTION
This just adds one value to the emits array to stop the vue warning message.


[Vue warn]: Component emitted event "cell-click" but it is neither declared in the emits option nor as an "onCell-click" prop.
![image](https://user-images.githubusercontent.com/15821271/114788151-f9ddba80-9d4e-11eb-9e6d-a5e41d697e2a.png)

<!-- Thank you for helping Oruga! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Add 'cell-click' value to array 'emits'

