### PR TITLE
Fix typo in rightIconClick event

### DIFF
--- a/packages/oruga-next/src/components/input/Input.vue
+++ b/packages/oruga-next/src/components/input/Input.vue
@@ -289,7 +289,7 @@ export default defineComponent({
             })
         },
 
-        rrightIconClick(event) {
+        rightIconClick(event) {
             if (this.passwordReveal) {
                 this.togglePasswordVisibility()
             } else if (this.clearable) {


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #127 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes
- Rename `rrightIconClick` to `rightIconClick`
