### PR TITLE
Add loading prop to button

### DIFF
--- a/packages/oruga/src/components/button/Button.spec.js
+++ b/packages/oruga/src/components/button/Button.spec.js
@@ -87,4 +87,18 @@ describe('OButton', () => {
         })
         expect(wrapper.vm.computedTag).toBe('button')
     })
+
+    it('should set tag to "button" if loading', () => {
+        wrapper.setProps({
+            tag: 'a'
+        })
+        expect(wrapper.vm.computedTag).toBe('a')
+
+        wrapper = shallowMount(OButton, {
+            attrs: {
+                'loading': true
+            }
+        })
+        expect(wrapper.vm.computedTag).toBe('button')
+    })
 })

--- a/packages/oruga/src/components/button/Button.vue
+++ b/packages/oruga/src/components/button/Button.vue
@@ -29,6 +29,11 @@
                 :class="iconClasses"
             />
         </span>
+        <div v-if="loading" :class="loadingSpinnerClasses">
+            <slot name="loading">
+                <o-icon icon="loading" :size="size" spin />
+            </slot>
+        </div>
     </component>
 </template>
 
@@ -123,6 +128,10 @@ export default {
          * Button will be disabled
          */
         disabled: Boolean,
+        /**
+         * Button represents an active action
+         */
+        loading: Boolean,
         /**  @ignore */
         iconBoth: Boolean, // This is used internally
         rootClass: [String, Function, Array],
@@ -131,6 +140,8 @@ export default {
         expandedClass: [String, Function, Array],
         roundedClass: [String, Function, Array],
         disabledClass: [String, Function, Array],
+        loadingClass: [String, Function, Array],
+        loadingSpinnerClass: [String, Function, Array],
         iconClass: [String, Function, Array],
         sizeClass: [String, Function, Array],
         variantClass: [String, Function, Array]
@@ -148,12 +159,18 @@ export default {
                 { [this.computedClass('expandedClass', 'o-btn--expanded')]: this.expanded },
                 { [this.computedClass('roundedClass', 'o-btn--rounded')]: this.rounded },
                 { [this.computedClass('disabledClass', 'o-btn--disabled')]: this.disabled },
+                { [this.computedClass('loadingClass', 'o-btn--loading')]: this.loading },
             ]
         },
         iconClasses() {
-          return [
-            this.computedClass('iconClass', 'o-btn__icon'),
-          ]
+            return [
+                this.computedClass('iconClass', 'o-btn__icon'),
+            ]
+        },
+        loadingSpinnerClasses() {
+            return [
+                this.computedClass('loadingSpinnerClass', 'o-btn__spinner'),
+            ]
         },
         elementsWrapperClasses() {
             return [
@@ -161,9 +178,13 @@ export default {
             ]
         },
         computedTag() {
-            if (this.disabled !== undefined && this.disabled !== false) {
+            const isNotDisabled = this.disabled !== undefined && this.disabled !== false;
+            const isNotLoading = this.loading !== undefined && this.loading !== false;
+
+            if (isNotDisabled && isNotLoading) {
                 return 'button'
             }
+
             return this.tag
         },
         computedNativeType() {

--- a/packages/oruga/src/components/button/Inspector.vue
+++ b/packages/oruga/src/components/button/Inspector.vue
@@ -63,6 +63,14 @@ export default {
                     },
                 },
                 {
+                    class: "loadingClass",
+                    description: "Class of the button when loading",
+                    properties: ["loading"],
+                    action: (cmp) => {
+                        cmp.data.loading = true;
+                    },
+                },
+                {
                     class: "iconClass",
                     description: "Class of the button icon",
                     properties: ["iconLeft", "iconRight"],

--- a/packages/oruga/src/components/button/examples/Button.md
+++ b/packages/oruga/src/components/button/examples/Button.md
@@ -41,6 +41,7 @@
             <o-button>Normal</o-button>
             <o-button disabled>Disabled</o-button>
             <o-button rounded>Rounded</o-button>
+            <o-button loading>Loading</o-button>
         </div>
 
         <div class="buttons">

--- a/packages/oruga/src/scss/components/_button.scss
+++ b/packages/oruga/src/scss/components/_button.scss
@@ -46,6 +46,16 @@ $button-disabled-opacity: $base-disabled-opacity !default;
         align-items: center;
         position: relative;
     }
+    &__spinner {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+    }
     &--expanded {
         width: 100%;
     }
@@ -56,6 +66,12 @@ $button-disabled-opacity: $base-disabled-opacity !default;
         @include avariable('opacity', 'button-disabled-opacity', $button-disabled-opacity);
         cursor: not-allowed;
         pointer-events: none;
+    }
+    &--loading {
+        pointer-events: none;
+    }
+    &--loading &__wrapper {
+        opacity: 0;
     }
     @each $name, $value in $sizes {
         &--#{$name} {


### PR DESCRIPTION
Added a loading prop to the button component, useful to convey an asynchronous background task triggered by the button. Similar to the disabled prop, mouse events will be disabled when a button is marked as loading. This prop acts similar to the loading prop in Vuetify.

![hK1WHdeD6i](https://user-images.githubusercontent.com/7606171/123807977-a06a3e00-d8f0-11eb-8322-b48abdba7836.gif)

I've not implemented these changes in oruga-next since I believe thats better left up to someone else. If you have any further questions or changes I need to make feel free to let me know :)

## Proposed Changes

- Add a "loading" prop to buttons
  - Provides a loading slot to further customize loader appearence