### PR TITLE
deep watch arrays in Table component

### DIFF
--- a/packages/oruga-next/src/components/table/Table.vue
+++ b/packages/oruga-next/src/components/table/Table.vue
@@ -804,17 +804,20 @@ export default defineComponent({
         *   3. Sort again if it's not backend-sorted.
         *   4. Set new total if it's not backend-paginated.
         */
-        data(value) {
-            this.newData = value
-            if (!this.backendFiltering) {
-                this.newData = value.filter((row) => this.isRowFiltered(row))
-            }
-            if (!this.backendSorting) {
-                this.sort(this.currentSortColumn, true)
-            }
-            if (!this.backendPagination) {
-                this.newDataTotal = this.newData.length
-            }
+        data: {
+            handler(value) {
+                this.newData = value
+                if (!this.backendFiltering) {
+                    this.newData = value.filter((row) => this.isRowFiltered(row))
+                }
+                if (!this.backendSorting) {
+                    this.sort(this.currentSortColumn, true)
+                }
+                if (!this.backendPagination) {
+                    this.newDataTotal = this.newData.length
+                }
+            },
+            deep: true,
         },
 
         /**
@@ -835,8 +838,11 @@ export default defineComponent({
         * When checkedRows prop change, update internal value without
         * mutating original data.
         */
-        checkedRows(rows) {
-            this.newCheckedRows = [...rows]
+        checkedRows: {
+            handler(rows) {
+                this.newCheckedRows = [...rows]
+            },
+            deep: true,
         },
 
         debounceSearch: {
@@ -854,7 +860,7 @@ export default defineComponent({
                     this.handleFiltersChange(value)
                 }
             },
-            deep: true
+            deep: true,
         },
 
         /**


### PR DESCRIPTION
When running oruga-next with compat mode in Vue3, it's showing me warnings in the console. See the link they provide along the warnings: https://v3.vuejs.org/guide/migration/watch.html

I had problems with auto-formatting in VSCode, it was changing the whole file. Unfortunately the editorconfig may be missing some settings. But I'm not very confident with the setting up formatters in general. :-/ 