### PR TITLE
Fix the path to load helper in `OTableMobileSort` (oruga-next)

### DIFF
--- a/packages/oruga-next/src/components/table/TableMobileSort.vue
+++ b/packages/oruga-next/src/components/table/TableMobileSort.vue
@@ -43,7 +43,7 @@ import Select from '../select/Select.vue'
 import Icon from '../icon/Icon.vue'
 import Field from '../field/Field.vue'
 
-import { getValueByPath } from '../../../../oruga/src/utils/helpers'
+import { getValueByPath } from '../../utils/helpers'
 
 export default defineComponent({
     name: 'OTableMobileSort',


### PR DESCRIPTION
Fixes an error that occurs when using oruga-next alone: it tries to load a helper funcion (`getValueByPath`) from the oruga package.
