### PR TITLE
Add 'iconPack' to notification props

### DIFF
--- a/packages/oruga-next/src/components/notification/Notification.vue
+++ b/packages/oruga-next/src/components/notification/Notification.vue
@@ -82,6 +82,11 @@ export default {
             type: String,
             default: 'fade'
         },
+         /**
+         * Icon pack to use
+         * @values mdi, fa, fas and any other custom icon pack
+         */
+        iconPack: String,
         /** Component to be injected, used to open a component modal programmatically. Close modal within the component by emitting a 'close' event — this.$emit('close') */
         component: [Object, Function],
         /** Props to be binded to the injected component */


### PR DESCRIPTION
fix(notification): add missing 'iconPack' argument to notification props, to allow an icon pack besides the default to be set on this component.