### PR TITLE
feat: add transformClasses functionality

### DIFF
--- a/packages/docs/documentation/README.md
+++ b/packages/docs/documentation/README.md
@@ -472,7 +472,31 @@ Vue.use(Config, {
 })
 ```
 
+### Transform classes
 
+In case you want to transform applied classes' names you can use `transformClasses` function directly in your configuration.
+
+```js
+Vue.use(Config, {
+    button: {
+        transformClasses: (appliedClasses) => {
+            return appliedClasses.replace(/-/g, '--')
+        }
+    }
+    ...
+})
+```
+
+You can also use `transformClasses` globally if you need to transform classes for any component.
+
+```js
+Vue.use(Config, {
+    transformClasses: (appliedClasses) => {
+        return appliedClasses.replace(/-/g, '--')
+    }
+    ...
+})
+```
 
 ### Using CSS or SASS/SCSS variables
 

--- a/packages/oruga-next/src/utils/BaseComponentMixin.ts
+++ b/packages/oruga-next/src/utils/BaseComponentMixin.ts
@@ -28,8 +28,11 @@ export default defineComponent({
         computedClass(field: string, defaultValue: string, suffix: string = '') {
             const config = getOptions()
 
-            let override = this.$props.override || getValueByPath(config, `${this.$options.configField}.override`, false)
-            let overrideClass = getValueByPath(config, `${this.$options.configField}.${field}.override`, override)
+            const override = this.$props.override || getValueByPath(config, `${this.$options.configField}.override`, false)
+            const overrideClass = getValueByPath(config, `${this.$options.configField}.${field}.override`, override)
+
+            const globalTransformClasses = config.transformClasses || undefined
+            const localTransformClasses = getValueByPath(config, `${this.$options.configField}.transformClasses`, undefined)
 
             let globalClass = getValueByPath(config, `${this.$options.configField}.${field}.class`, '')
                 || getValueByPath(config, `${this.$options.configField}.${field}`, '')
@@ -55,9 +58,16 @@ export default defineComponent({
             } else {
                 globalClass = _defaultSuffixProcessor(globalClass, suffix)
             }
-            return (`${(override && !overrideClass) || (!override && !overrideClass) ? defaultValue : ''} `
+            let appliedClasses = (`${(override && !overrideClass) || (!override && !overrideClass) ? defaultValue : ''} `
                + `${blankIfUndefined(globalClass)} `
                + `${blankIfUndefined(currentClass)}`).trim().replace(/\s\s+/g, ' ');
+            if (localTransformClasses) {
+                appliedClasses = localTransformClasses(appliedClasses)
+            }
+            if (globalTransformClasses) {
+                appliedClasses = globalTransformClasses(appliedClasses)
+            }
+            return appliedClasses
         }
     }
 })

--- a/packages/oruga-next/src/utils/config.ts
+++ b/packages/oruga-next/src/utils/config.ts
@@ -4,7 +4,8 @@ import { merge } from "./helpers"
 let config = {
     iconPack: 'mdi',
     useHtml5Validation: true,
-    statusIcon: true
+    statusIcon: true,
+    transformClasses: undefined
 }
 
 export const setOptions = (options: any) => { config = options }

--- a/packages/oruga/src/utils/BaseComponentMixin.spec.js
+++ b/packages/oruga/src/utils/BaseComponentMixin.spec.js
@@ -188,5 +188,60 @@ describe('BaseComponentMixin', () => {
             expect(wrapper.vm.computedClass('sizeClass', initialSizeClassValue, sizeSuffix))
                 .toBe(`${newGlobalSizeClassValue}suff-${sizeSuffix} ${newSizeClassValue}suff-${sizeSuffix}`)
         })
+        it('transform global and local classes as expected', async () => {
+            // TODO test local classes -- rootClass
+            const initialRootClassValue = 'initial-class'
+            const newGlobalRootClassValue = 'new-global-class'
+            const newRootClassValue = 'new-class'
+
+
+            // Locally
+            setOptions(merge(getOptions(), {
+                button: {
+                    rootClass: newGlobalRootClassValue,
+                    override: false,
+                    transformClasses: (appliedClasses) => {
+                        return appliedClasses.replace(/-/g, '--')
+                    }
+                }
+            }, true))
+            wrapper.setProps({ rootClass: newRootClassValue })
+            await wrapper.vm.$nextTick()
+            expect(wrapper.vm.computedClass('rootClass', initialRootClassValue))
+                .toBe(`${initialRootClassValue} ${newGlobalRootClassValue} ${newRootClassValue}`.replace(/-/g, '--'))
+
+            // Globally
+            setOptions({})
+            setOptions(merge(getOptions(), {
+                transformClasses: (appliedClasses) => {
+                    return appliedClasses.replace(/-/g, '--')
+                },
+                button: {
+                    rootClass: newGlobalRootClassValue,
+                    override: true
+                }
+            }, true))
+            await wrapper.vm.$nextTick()
+            expect(wrapper.vm.computedClass('rootClass', initialRootClassValue))
+                .toBe(`${newGlobalRootClassValue} ${newRootClassValue}`.replace(/-/g, '--'))
+
+            // Both globally and locally
+            setOptions({})
+            setOptions(merge(getOptions(), {
+                transformClasses: (appliedClasses) => {
+                    return appliedClasses.replace(/-/g, '__')
+                },
+                button: {
+                    rootClass: newGlobalRootClassValue,
+                    override: true,
+                    transformClasses: (appliedClasses) => {
+                        return appliedClasses.replace(/-/g, '--')
+                    },
+                }
+            }, true))
+            await wrapper.vm.$nextTick()
+            expect(wrapper.vm.computedClass('rootClass', initialRootClassValue))
+                .toBe(`${newGlobalRootClassValue} ${newRootClassValue}`.replace(/-/g, '--').replace(/-/g, '__'))
+        })
     })
 })


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #184 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

In case you want to transform applied classes' names you can use `transformClasses` function directly in your configuration.

```js
Vue.use(Config, {
    button: {
        transformClasses: (appliedClasses) => {
            return appliedClasses.replace(/-/g, '--')
        }
    }
    ...
})
```

You can also use `transformClasses` globally if you need to transform classes for any component.

```js
Vue.use(Config, {
    transformClasses: (appliedClasses) => {
        return appliedClasses.replace(/-/g, '--')
    }
    ...
})
```
