### PR TITLE
Override prop behaviour 

### DIFF
--- a/packages/docs/documentation/README.md
+++ b/packages/docs/documentation/README.md
@@ -456,6 +456,10 @@ or directly in your component
     rootClass="myautocomplete-root">
 ```
 
+::: warning
+In this case `override` property replaces Oruga existing classes completely, ignoring your configuration.
+:::
+
 You can also specify the override behaviour for each class
 
 ```js

--- a/packages/oruga-next/src/utils/BaseComponentMixin.ts
+++ b/packages/oruga-next/src/utils/BaseComponentMixin.ts
@@ -26,12 +26,12 @@ export default defineComponent({
     },
     methods: {
         computedClass(field: string, defaultValue: string, suffix: string = '') {
-            const config = getOptions()
+            const config = this.$props.override === true ? {} : getOptions();
 
             const override = this.$props.override || getValueByPath(config, `${this.$options.configField}.override`, false)
             const overrideClass = getValueByPath(config, `${this.$options.configField}.${field}.override`, override)
 
-            const globalTransformClasses = config.transformClasses || undefined
+            const globalTransformClasses = getValueByPath(config, `transformClasses`, undefined)
             const localTransformClasses = getValueByPath(config, `${this.$options.configField}.transformClasses`, undefined)
 
             let globalClass = getValueByPath(config, `${this.$options.configField}.${field}.class`, '')
@@ -55,14 +55,10 @@ export default defineComponent({
             } else {
                 currentClass = _defaultSuffixProcessor(currentClass, suffix)
             }
-            if (this.$props.override !== true) {
-                if (typeof globalClass === "function") {
-                    globalClass = globalClass(suffix, context || _getContext(this))
-                } else {
-                    globalClass = _defaultSuffixProcessor(globalClass, suffix)
-                }
+            if (typeof globalClass === "function") {
+                globalClass = globalClass(suffix, context || _getContext(this))
             } else {
-                globalClass = ''
+                globalClass = _defaultSuffixProcessor(globalClass, suffix)
             }
             let appliedClasses = (`${(override && !overrideClass) || (!override && !overrideClass) ? defaultValue : ''} `
                + `${blankIfUndefined(globalClass)} `

--- a/packages/oruga-next/src/utils/BaseComponentMixin.ts
+++ b/packages/oruga-next/src/utils/BaseComponentMixin.ts
@@ -48,15 +48,21 @@ export default defineComponent({
                 defaultValue = defaultValue + suffix
             }
 
+            let context = null
             if (typeof currentClass === "function") {
-                currentClass = currentClass(suffix, _getContext(this))
+                context = _getContext(this)
+                currentClass = currentClass(suffix, context)
             } else {
                 currentClass = _defaultSuffixProcessor(currentClass, suffix)
             }
-            if (typeof globalClass === "function") {
-                globalClass = globalClass(suffix, _getContext(this))
+            if (this.$props.override !== true) {
+                if (typeof globalClass === "function") {
+                    globalClass = globalClass(suffix, context || _getContext(this))
+                } else {
+                    globalClass = _defaultSuffixProcessor(globalClass, suffix)
+                }
             } else {
-                globalClass = _defaultSuffixProcessor(globalClass, suffix)
+                globalClass = ''
             }
             let appliedClasses = (`${(override && !overrideClass) || (!override && !overrideClass) ? defaultValue : ''} `
                + `${blankIfUndefined(globalClass)} `

--- a/packages/oruga/src/utils/BaseComponentMixin.js
+++ b/packages/oruga/src/utils/BaseComponentMixin.js
@@ -56,14 +56,18 @@ export default {
             let context = null
             if (typeof currentClass === "function") {
                 context = _getContext(this)
-                currentClass = currentClass(suffix, )
+                currentClass = currentClass(suffix, context)
             } else {
                 currentClass = _defaultSuffixProcessor(currentClass, suffix)
             }
-            if (typeof globalClass === "function") {
-                globalClass = globalClass(suffix, context || _getContext(this))
+            if (this.$props.override !== true) {
+                if (typeof globalClass === "function") {
+                    globalClass = globalClass(suffix, context || _getContext(this))
+                } else {
+                    globalClass = _defaultSuffixProcessor(globalClass, suffix)
+                }
             } else {
-                globalClass = _defaultSuffixProcessor(globalClass, suffix)
+                globalClass = ''
             }
             let appliedClasses = (`${(override && !overrideClass) || (!override && !overrideClass) ? defaultValue : ''} `
                + `${blankIfUndefined(globalClass)} `

--- a/packages/oruga/src/utils/BaseComponentMixin.js
+++ b/packages/oruga/src/utils/BaseComponentMixin.js
@@ -31,12 +31,12 @@ export default {
     },
     methods: {
         computedClass(field, defaultValue, suffix='') {
-            const config = getOptions();
+            const config = this.$props.override === true ? {} : getOptions();
 
             const override = this.$props.override || getValueByPath(config, `${this.$options.configField}.override`, false)
             const overrideClass = getValueByPath(config, `${this.$options.configField}.${field}.override`, override)
 
-            const globalTransformClasses = config.transformClasses || undefined
+            const globalTransformClasses = getValueByPath(config, `transformClasses`, undefined)
             const localTransformClasses = getValueByPath(config, `${this.$options.configField}.transformClasses`, undefined)
 
             let globalClass = getValueByPath(config, `${this.$options.configField}.${field}.class`, '')
@@ -60,14 +60,10 @@ export default {
             } else {
                 currentClass = _defaultSuffixProcessor(currentClass, suffix)
             }
-            if (this.$props.override !== true) {
-                if (typeof globalClass === "function") {
-                    globalClass = globalClass(suffix, context || _getContext(this))
-                } else {
-                    globalClass = _defaultSuffixProcessor(globalClass, suffix)
-                }
+            if (typeof globalClass === "function") {
+                globalClass = globalClass(suffix, context || _getContext(this))
             } else {
-                globalClass = ''
+                globalClass = _defaultSuffixProcessor(globalClass, suffix)
             }
             let appliedClasses = (`${(override && !overrideClass) || (!override && !overrideClass) ? defaultValue : ''} `
                + `${blankIfUndefined(globalClass)} `

--- a/packages/oruga/src/utils/BaseComponentMixin.spec.js
+++ b/packages/oruga/src/utils/BaseComponentMixin.spec.js
@@ -103,7 +103,7 @@ describe('BaseComponentMixin', () => {
 
             /* Override all except sizeClass */
 
-            setOptions(merge(getOptions(), {
+            setOptions({
                 button: {
                     override: true,
                     rootClass: {
@@ -114,7 +114,7 @@ describe('BaseComponentMixin', () => {
                         class: newGlobalSizeClassValue,
                     },
                 }
-            }, true))
+            }, true)
             wrapper.setProps({ rootClass: newRootClassValue, sizeClass: newSizeClassValue })
             await wrapper.vm.$nextTick()
             expect(wrapper.vm.computedClass('rootClass', initialRootClassValue))
@@ -125,7 +125,7 @@ describe('BaseComponentMixin', () => {
 
 
             /* Override only sizeClass */
-            setOptions(merge(getOptions(), {
+            setOptions({
                 button: {
                     rootClass: {
                         class: newGlobalRootClassValue,
@@ -135,7 +135,7 @@ describe('BaseComponentMixin', () => {
                         override: true
                     },
                 }
-            }, true))
+            }, true)
             wrapper.setProps({ rootClass: newRootClassValue, sizeClass: newSizeClassValue })
             await wrapper.vm.$nextTick()
             expect(wrapper.vm.computedClass('rootClass', initialRootClassValue))
@@ -145,7 +145,7 @@ describe('BaseComponentMixin', () => {
                 .toBe(`${newGlobalSizeClassValue}${sizeSuffix} ${newSizeClassValue}${sizeSuffix}`)
 
             /* Override sizeClass using a function */
-            setOptions(merge(getOptions(), {
+            setOptions({
                 button: {
                     rootClass: {
                         class: newGlobalRootClassValue,
@@ -157,7 +157,7 @@ describe('BaseComponentMixin', () => {
                         override: true
                     },
                 }
-            }, true))
+            }, true)
             wrapper.setProps({ rootClass: newRootClassValue, sizeClass: newSizeClassValue })
             await wrapper.vm.$nextTick()
             expect(wrapper.vm.computedClass('rootClass', initialRootClassValue))
@@ -167,7 +167,7 @@ describe('BaseComponentMixin', () => {
                 .toBe(`${newGlobalSizeClassValue}suff-${sizeSuffix} ${newSizeClassValue}${sizeSuffix}`)
 
             /* Override sizeClass from prop using a function */
-            setOptions(merge(getOptions(), {
+            setOptions({
                 button: {
                     rootClass: {
                         class: newGlobalRootClassValue,
@@ -179,7 +179,7 @@ describe('BaseComponentMixin', () => {
                         override: true
                     },
                 }
-            }, true))
+            }, true)
             wrapper.setProps({ rootClass: newRootClassValue, sizeClass: (suffix) => `${newSizeClassValue}suff-${suffix}` })
             await wrapper.vm.$nextTick()
             expect(wrapper.vm.computedClass('rootClass', initialRootClassValue))
@@ -187,6 +187,28 @@ describe('BaseComponentMixin', () => {
 
             expect(wrapper.vm.computedClass('sizeClass', initialSizeClassValue, sizeSuffix))
                 .toBe(`${newGlobalSizeClassValue}suff-${sizeSuffix} ${newSizeClassValue}suff-${sizeSuffix}`)
+
+            /* Override true as prop */
+            setOptions({
+                button: {
+                    rootClass: {
+                        class: newGlobalRootClassValue,
+                    },
+                    sizeClass: {
+                        class: (suffix) => {
+                            return `${newGlobalSizeClassValue}suff-${suffix}`
+                        },
+                        override: true
+                    },
+                }
+            }, true)
+            wrapper.setProps({ override: true, rootClass: newRootClassValue, sizeClass: (suffix) => `${newSizeClassValue}suff-${suffix}` })
+            await wrapper.vm.$nextTick()
+            expect(wrapper.vm.computedClass('rootClass', initialRootClassValue))
+                .toBe(`${newRootClassValue}`)
+
+            expect(wrapper.vm.computedClass('sizeClass', initialSizeClassValue, sizeSuffix))
+                .toBe(`${newSizeClassValue}suff-${sizeSuffix}`)
         })
         it('transform global and local classes as expected', async () => {
             // TODO test local classes -- rootClass
@@ -196,7 +218,7 @@ describe('BaseComponentMixin', () => {
 
 
             // Locally
-            setOptions(merge(getOptions(), {
+            setOptions({
                 button: {
                     rootClass: newGlobalRootClassValue,
                     override: false,
@@ -204,15 +226,14 @@ describe('BaseComponentMixin', () => {
                         return appliedClasses.replace(/-/g, '--')
                     }
                 }
-            }, true))
+            })
             wrapper.setProps({ rootClass: newRootClassValue })
             await wrapper.vm.$nextTick()
             expect(wrapper.vm.computedClass('rootClass', initialRootClassValue))
                 .toBe(`${initialRootClassValue} ${newGlobalRootClassValue} ${newRootClassValue}`.replace(/-/g, '--'))
 
             // Globally
-            setOptions({})
-            setOptions(merge(getOptions(), {
+            setOptions({
                 transformClasses: (appliedClasses) => {
                     return appliedClasses.replace(/-/g, '--')
                 },
@@ -220,14 +241,13 @@ describe('BaseComponentMixin', () => {
                     rootClass: newGlobalRootClassValue,
                     override: true
                 }
-            }, true))
+            })
             await wrapper.vm.$nextTick()
             expect(wrapper.vm.computedClass('rootClass', initialRootClassValue))
                 .toBe(`${newGlobalRootClassValue} ${newRootClassValue}`.replace(/-/g, '--'))
 
             // Both globally and locally
-            setOptions({})
-            setOptions(merge(getOptions(), {
+            setOptions({
                 transformClasses: (appliedClasses) => {
                     return appliedClasses.replace(/-/g, '__')
                 },
@@ -238,7 +258,7 @@ describe('BaseComponentMixin', () => {
                         return appliedClasses.replace(/-/g, '--')
                     },
                 }
-            }, true))
+            })
             await wrapper.vm.$nextTick()
             expect(wrapper.vm.computedClass('rootClass', initialRootClassValue))
                 .toBe(`${newGlobalRootClassValue} ${newRootClassValue}`.replace(/-/g, '--').replace(/-/g, '__'))

--- a/packages/oruga/src/utils/BaseComponentMixin.spec.js
+++ b/packages/oruga/src/utils/BaseComponentMixin.spec.js
@@ -114,7 +114,7 @@ describe('BaseComponentMixin', () => {
                         class: newGlobalSizeClassValue,
                     },
                 }
-            }, true)
+            })
             wrapper.setProps({ rootClass: newRootClassValue, sizeClass: newSizeClassValue })
             await wrapper.vm.$nextTick()
             expect(wrapper.vm.computedClass('rootClass', initialRootClassValue))
@@ -135,7 +135,7 @@ describe('BaseComponentMixin', () => {
                         override: true
                     },
                 }
-            }, true)
+            })
             wrapper.setProps({ rootClass: newRootClassValue, sizeClass: newSizeClassValue })
             await wrapper.vm.$nextTick()
             expect(wrapper.vm.computedClass('rootClass', initialRootClassValue))
@@ -157,7 +157,7 @@ describe('BaseComponentMixin', () => {
                         override: true
                     },
                 }
-            }, true)
+            })
             wrapper.setProps({ rootClass: newRootClassValue, sizeClass: newSizeClassValue })
             await wrapper.vm.$nextTick()
             expect(wrapper.vm.computedClass('rootClass', initialRootClassValue))
@@ -179,7 +179,7 @@ describe('BaseComponentMixin', () => {
                         override: true
                     },
                 }
-            }, true)
+            })
             wrapper.setProps({ rootClass: newRootClassValue, sizeClass: (suffix) => `${newSizeClassValue}suff-${suffix}` })
             await wrapper.vm.$nextTick()
             expect(wrapper.vm.computedClass('rootClass', initialRootClassValue))
@@ -189,6 +189,10 @@ describe('BaseComponentMixin', () => {
                 .toBe(`${newGlobalSizeClassValue}suff-${sizeSuffix} ${newSizeClassValue}suff-${sizeSuffix}`)
 
             /* Override true as prop */
+            wrapper = shallowMount(OButton, {
+                attachToDocument: true,
+                mixins: [BaseComponentMixin]
+            })
             setOptions({
                 button: {
                     rootClass: {
@@ -198,17 +202,16 @@ describe('BaseComponentMixin', () => {
                         class: (suffix) => {
                             return `${newGlobalSizeClassValue}suff-${suffix}`
                         },
-                        override: true
                     },
                 }
-            }, true)
-            wrapper.setProps({ override: true, rootClass: newRootClassValue, sizeClass: (suffix) => `${newSizeClassValue}suff-${suffix}` })
+            })
+            wrapper.setProps({ override: true, rootClass: newRootClassValue })
             await wrapper.vm.$nextTick()
             expect(wrapper.vm.computedClass('rootClass', initialRootClassValue))
                 .toBe(`${newRootClassValue}`)
 
             expect(wrapper.vm.computedClass('sizeClass', initialSizeClassValue, sizeSuffix))
-                .toBe(`${newSizeClassValue}suff-${sizeSuffix}`)
+                .toBe(``)
         })
         it('transform global and local classes as expected', async () => {
             // TODO test local classes -- rootClass


### PR DESCRIPTION
`override` property now replaces Oruga existing classes completely, ignoring configuration.

