### PR TITLE
Changed deprecated .sync to v-model

### DIFF
--- a/packages/oruga/src/components/sidebar/examples/Sidebar.md
+++ b/packages/oruga/src/components/sidebar/examples/Sidebar.md
@@ -11,7 +11,7 @@
             :fullwidth="fullwidth"
             :overlay="overlay"
             :right="right"
-            :open.sync="open"
+            v-model:open="open"
             >
             <o-button v-if="fullwidth" icon-left="times" label="Close" @click="open = false" />
             <img


### PR DESCRIPTION
'.sync' modifier on 'v-bind' directive is deprecated. Use 'v-model:propName' instead  vue/no-deprecated-v-bind-sync

<!-- Thank you for helping Oruga! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

-
-
-
