### PR TITLE
fix: slots syntax to vue 3 syntax

### DIFF
--- a/packages/oruga-next/src/components/autocomplete/Autocomplete.vue
+++ b/packages/oruga-next/src/components/autocomplete/Autocomplete.vue
@@ -605,10 +605,10 @@ export default defineComponent({
                 const data = this.computedData.map(
                     (d) => d.items).reduce((a, b) => ([...a, ...b]), [])
 
-                if (this.$slots.header && this.selectableHeader) {
+                if (this.$slots.header() && this.selectableHeader) {
                     data.unshift(undefined)
                 }
-                if (this.$slots.footer && this.selectableFooter) {
+                if (this.$slots.footer() && this.selectableFooter) {
                     data.push(undefined)
                 }
                 let index
@@ -626,20 +626,20 @@ export default defineComponent({
                 this.footerHovered = false
                 this.headerHovered = false
                 this.setHovered(data[index] !== undefined ? data[index] : null)
-                if (this.$slots.footer && this.selectableFooter && index === data.length - 1) {
+                if (this.$slots.footer() && this.selectableFooter && index === data.length - 1) {
                     this.footerHovered = true
                 }
-                if (this.$slots.header && this.selectableHeader && index === 0) {
+                if (this.$slots.header() && this.selectableHeader && index === 0) {
                     this.headerHovered = true
                 }
 
                 const list = this.$refs.dropdown
                 let items = this.$refs.items || []
 
-                if (this.$slots.header && this.selectableHeader) {
+                if (this.$slots.header() && this.selectableHeader) {
                     items = [this.$refs.header, ...items]
                 }
-                if (this.$slots.footer && this.selectableFooter) {
+                if (this.$slots.footer() && this.selectableFooter) {
                     items = [...items, this.$refs.footer]
                 }
                 const element = items[index]

--- a/packages/oruga-next/src/components/collapse/Collapse.spec.js
+++ b/packages/oruga-next/src/components/collapse/Collapse.spec.js
@@ -87,7 +87,7 @@ describe('OCollapse', () => {
     it('should have scoped trigger slot', () => {
         const triggerSlot = '<strong> Header </strong>'
         const wrapper = shallowMount(OCollapse, {
-            scopedSlots: {
+            slots: {
                 trigger: triggerSlot
             }
         })

--- a/packages/oruga-next/src/components/field/Field.vue
+++ b/packages/oruga-next/src/components/field/Field.vue
@@ -187,10 +187,10 @@ export default defineComponent({
             return this.$field
         },
         hasLabelSlot() {
-            return this.$slots.label
+            return this.$slots.label()
         },
         hasMessageSlot() {
-            return this.$slots.message
+            return this.$slots.message()
         },
         hasLabel() {
             return this.label || this.hasLabelSlot

--- a/packages/oruga-next/src/components/inputitems/Inputitems.vue
+++ b/packages/oruga-next/src/components/inputitems/Inputitems.vue
@@ -301,19 +301,19 @@ export default defineComponent({
         },
 
         hasDefaultSlot() {
-            return !!this.$slots.default
+            return !!this.$slots.default()
         },
 
         hasEmptySlot() {
-            return !!this.$slots.empty
+            return !!this.$slots.empty()
         },
 
         hasHeaderSlot() {
-            return !!this.$slots.header
+            return !!this.$slots.header()
         },
 
         hasFooterSlot() {
-            return !!this.$slots.footer
+            return !!this.$slots.footer()
         },
 
         /**

--- a/packages/oruga-next/src/components/pagination/Pagination.vue
+++ b/packages/oruga-next/src/components/pagination/Pagination.vue
@@ -355,13 +355,13 @@ export default defineComponent({
         },
 
         hasDefaultSlot() {
-            return this.$slots.default
+            return this.$slots.default()
         },
         hasPreviousSlot() {
-            return this.$slots.previous
+            return this.$slots.previous()
         },
         hasNextSlot() {
-            return this.$slots.next
+            return this.$slots.next()
         }
     },
     watch: {

--- a/packages/oruga-next/src/components/table/Table.vue
+++ b/packages/oruga-next/src/components/table/Table.vue
@@ -146,8 +146,8 @@
                     >
                         <template
                             v-if="
-                                column.$scopedSlots &&
-                                column.$scopedSlots.subheading
+                                column.$slots &&
+                                column.$slots.subheading
                             ">
                             <o-slot-component
                                 :component="column"
@@ -831,9 +831,9 @@ export default defineComponent({
         },
 
         hasCustomSubheadings() {
-            if (this.$scopedSlots && this.$scopedSlots.subheading) return true
+            if (this.$slots && this.$slots.subheading()) return true
             return this.newColumns.some((column) => {
-                return column.subheading || (column.$scopedSlots && column.$scopedSlots.subheading)
+                return column.subheading || (column.$slots && column.$slots.subheading())
             })
         },
     },
@@ -1271,7 +1271,7 @@ export default defineComponent({
         * Check if footer slot has custom content.
         */
         hasCustomFooterSlot() {
-            const footer = this.$slots.footer
+            const footer = this.$slots.footer()
             if (footer.length > 1) return true
 
             const tag = footer[0].tag

--- a/packages/oruga-next/src/components/table/TableColumn.vue
+++ b/packages/oruga-next/src/components/table/TableColumn.vue
@@ -65,13 +65,13 @@ export default defineComponent({
             }
         },
         hasDefaultSlot() {
-            return this.$slots.default
+            return this.$slots.default()
         },
         hasSearchableSlot() {
-            return this.$slots.searchable
+            return this.$slots.searchable()
         },
         hasHeaderSlot() {
-            return this.$slots.header
+            return this.$slots.header()
         },
         isHeaderUnselectable() {
             return !this.headerSelectable && this.sortable


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #208

## Proposed Changes
as in [migration guide ](https://v3.vuejs.org/guide/migration/slots-unification.html#_3-x-syntax)

- Replace all this.$scopedSlots with this.$slots
- Replace all of this.$slots.mySlot with this.$slots.mySlot()

