### PR TITLE
🐛 Include default input background to Inputitems container as well

### DIFF
--- a/packages/docs/components/InputItems.md
+++ b/packages/docs/components/InputItems.md
@@ -471,6 +471,7 @@ export default {
 
 | CSS Variable                             | SASS Variable                      | Default                          |
 | ---------------------------------------- | ---------------------------------- | -------------------------------- |
+| --oruga-inputitems-background-color      | \$inputitems-background-color      | $input-background-color          |
 | --oruga-inputitems-height                | \$inputitems-height                | calc(2em - 1px)                  |
 | --oruga-inputitems-padding               | \$inputitems-padding               | calc(.275em - 1px) 0 0           |
 | --oruga-inputitems-border-color          | \$inputitems-border-color          | \$grey-lighter                   |

--- a/packages/oruga/src/scss/components/_inputitems.scss
+++ b/packages/oruga/src/scss/components/_inputitems.scss
@@ -1,4 +1,5 @@
 /* @docs */
+$inputitems-background-color: $input-background-color !default;
 $inputitems-height: calc(2em - 1px) !default;
 $inputitems-padding: calc(.275em - 1px) 0 0 !default;
 $inputitems-border-color: $grey-lighter !default;
@@ -32,7 +33,7 @@ $inputitems-margin-icon-to-text: .1875em !default;
         @include avariable('max-width', 'inputitems-max-width', $inputitems-max-width);
         @include avariable('width', 'inputitems-width', $inputitems-width);
         @include avariable('padding', 'inputitems-padding', $inputitems-padding);
-        @include avariable('background-color', 'input-background-color', $input-background-color);
+        @include avariable('background-color', 'inputitems-background-color', $inputitems-background-color);
         @include avariable('border-color', 'inputitems-border-color', $inputitems-border-color);
         @include avariable('border-style', 'inputitems-border-style', $inputitems-border-style);
         @include avariable('border-width', 'inputitems-border-width', $inputitems-border-width);


### PR DESCRIPTION
## Proposed Changes

- Include default input background to Inputitems container as well

From this:
<img width="1073" alt="Skjermbilde 2021-10-28 kl  12 50 35" src="https://user-images.githubusercontent.com/42270947/139241974-4c1d5369-efdd-4789-be4f-48d2931aef28.png">

To this:
<img width="1056" alt="Skjermbilde 2021-10-28 kl  12 51 31" src="https://user-images.githubusercontent.com/42270947/139242008-db887524-5954-43ed-a964-e0fe2402c147.png">


