### PR TITLE
docs: Show usage of `iconPack` property to set custom icon pack as de…

### DIFF
--- a/packages/docs/components/Icon.md
+++ b/packages/docs/components/Icon.md
@@ -75,11 +75,11 @@ and <a href="https://fontawesome.com/" target="_blank">FontAwesome 5</a> but you
 ### Custom icon pack
 
 <p>
-    You can also add it during Oruga import as default config.
+    You can add it during Oruga setup and set it as the default config using the <code>iconPack</code> property.
 </p>
 
 ::: tip
-Take a look at below example code (click on "Show code") to know all internal icons to replace with the releated icons of your custom icon pack
+Take a look at the example code below (click on "Show code") to see how internal icons can be replaced with the corresponding icons of your custom icon pack.
 :::
 
 ::: demo
@@ -88,41 +88,41 @@ Take a look at below example code (click on "Show code") to know all internal ic
 <template>
   <section>
     <div class="block">
-      <o-icon pack="ionicons" icon="person" size="small"> </o-icon>
-      <o-icon pack="ionicons" icon="home" size="small"> </o-icon>
-      <o-icon pack="ionicons" icon="apps" size="small"> </o-icon>
+      <o-icon icon="person" size="small"> </o-icon>
+      <o-icon icon="home" size="small"> </o-icon>
+      <o-icon icon="apps" size="small"> </o-icon>
     </div>
 
     <div class="block">
-      <o-icon pack="ionicons" icon="person"> </o-icon>
-      <o-icon pack="ionicons" icon="home"> </o-icon>
-      <o-icon pack="ionicons" icon="apps"> </o-icon>
+      <o-icon icon="person"> </o-icon>
+      <o-icon icon="home"> </o-icon>
+      <o-icon icon="apps"> </o-icon>
     </div>
 
     <div class="block">
-      <o-icon pack="ionicons" icon="person" size="medium"> </o-icon>
-      <o-icon pack="ionicons" icon="home" size="medium"> </o-icon>
-      <o-icon pack="ionicons" icon="apps" size="medium"> </o-icon>
+      <o-icon icon="person" size="medium"> </o-icon>
+      <o-icon icon="home" size="medium"> </o-icon>
+      <o-icon icon="apps" size="medium"> </o-icon>
     </div>
 
     <div class="block">
-      <o-icon pack="ionicons" icon="person" size="large" variant="success"> </o-icon>
-      <o-icon pack="ionicons" icon="home" size="large" variant="info"> </o-icon>
-      <o-icon pack="ionicons" icon="apps" size="large" variant="primary"> </o-icon>
+      <o-icon icon="person" size="large" variant="success"> </o-icon>
+      <o-icon icon="home" size="large" variant="info"> </o-icon>
+      <o-icon icon="apps" size="large" variant="primary"> </o-icon>
     </div>
 
     <o-button variant="primary">
-      <o-icon pack="ionicons" icon="checkmark"></o-icon>
+      <o-icon icon="checkmark"></o-icon>
       <span>Finish</span>
     </o-button>
 
     <o-button variant="warning">
-      <o-icon pack="ionicons" icon="checkmark"></o-icon>
+      <o-icon icon="checkmark"></o-icon>
       <span>Finish</span>
     </o-button>
 
     <o-button variant="warning">
-      <o-icon spin pack="ionicons" icon="refresh"> </o-icon>
+      <o-icon spin icon="refresh"> </o-icon>
       <span>Refresh</span>
     </o-button>
   </section>
@@ -131,6 +131,7 @@ Take a look at below example code (click on "Show code") to know all internal ic
 <script>
   const customIconConfig = {
     iconComponent: undefined,
+    iconPack: 'ionicons',
     customIconPacks: {
       ionicons: {
         sizes: {


### PR DESCRIPTION
## Proposed Changes

- use `iconPack` property in code example instead of `pack` attribute for each `o-icon`, since introduction says "import as default config".