### PR TITLE
fix: rendering of comments in horizontal fields

### DIFF
--- a/packages/oruga-next/src/components/field/FieldBody.vue
+++ b/packages/oruga-next/src/components/field/FieldBody.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, h, resolveComponent } from "vue"
+import {defineComponent, h, resolveComponent, Comment, Text} from "vue"
 
 export default defineComponent({
     name: 'OFieldBody',
@@ -19,6 +19,9 @@ export default defineComponent({
             { class: this.parent.bodyHorizontalClasses },
             children.map((element) => {
                 let message
+                if (element.type === Comment || element.type === Text) {
+                    return element
+                }
                 if (first) {
                     message = this.parent.newMessage
                     first = false


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #226 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes
render `VNodes` of type `Comment` or `Text` as they are and do not wrap them in `OField`

-
-
-
