### PR TITLE
fix: missing 'active-change' event in Datepicker emits

### DIFF
--- a/packages/oruga-next/src/components/datepicker/Datepicker.vue
+++ b/packages/oruga-next/src/components/datepicker/Datepicker.vue
@@ -289,7 +289,7 @@ export default defineComponent({
             $datepicker: this
         }
     },
-    emits: ['update:modelValue', 'focus', 'blur', 'change-month', 'change-year', 'range-start', 'range-end'],
+    emits: ['update:modelValue', 'focus', 'blur', 'change-month', 'change-year', 'range-start', 'range-end', 'active-change'],
     props: {
         modelValue: {
             type: [Date, Array]


### PR DESCRIPTION
This change prevents the warnings when opening/closing the datepicker