### PR TITLE
fix: add missing parent param to programmatic loading component

### DIFF
--- a/packages/oruga/src/components/loading/index.js
+++ b/packages/oruga/src/components/loading/index.js
@@ -8,14 +8,21 @@ let localVueInstance
 
 const LoadingProgrammatic = {
     open(params) {
+        let parent
+
         const defaultParam = {
             programmatic: true
+        }
+        if (params.parent) {
+            parent = params.parent
+            delete params.parent
         }
         const propsData = merge(defaultParam, params)
 
         const vm = typeof window !== 'undefined' && window.Vue ? window.Vue : localVueInstance || VueInstance
         const LoadingComponent = vm.extend(Loading)
         return new LoadingComponent({
+            parent,
             el: document.createElement('div'),
             propsData
         })


### PR DESCRIPTION
This change makes programmatic loading component consistent with modal and notification components. It is needed as correct parent context may be necessary if a custom icon component is defined.