### PR TITLE
fix: set tabbed transitions correctly

### DIFF
--- a/packages/oruga-next/src/utils/TabbedMixin.ts
+++ b/packages/oruga-next/src/utils/TabbedMixin.ts
@@ -65,9 +65,9 @@ export default (cmp: string) => defineComponent({
          * When v-model is changed set the new active tab.
          */
         modelValue(value) {
-            this.performAction()
-            this.activeId = value
-            this.performAction()
+            if (this.activeId !== value) {
+                this.performAction(value)
+            }
         }
     },
     methods: {
@@ -76,19 +76,18 @@ export default (cmp: string) => defineComponent({
         */
         childClick(child: any) {
             if (this.activeId !== child.newValue) {
-                this.performAction()
-                this.activeId = child.newValue
-                this.performAction()
+                this.performAction(child.newValue)
                 this.$emit('update:modelValue', this.activeId)
             }
         },
         /**
         * Activate next child and deactivate prev child
         */
-        performAction() {
+        performAction(newId: number) {
             const oldValue = this.activeId
             const oldTab = oldValue !== undefined && oldValue !== null
                 ? this.childItems.filter((i: any) => i.newValue === oldValue)[0] : this.items[0]
+            this.activeId = newId
             if (oldTab && this.activeItem) {
                 oldTab.deactivate(this.activeItem.index)
                 this.activeItem.activate(oldTab.index)

--- a/packages/oruga/src/utils/TabbedMixin.js
+++ b/packages/oruga/src/utils/TabbedMixin.js
@@ -62,9 +62,9 @@ export default (cmp) => ({
          * When v-model is changed set the new active tab.
          */
         value(value) {
-            this.performAction()
-            this.activeId = value
-            this.performAction()
+            if (this.activeId !== value) {
+                this.performAction(value)
+            }
         },
     },
     methods: {
@@ -73,19 +73,18 @@ export default (cmp) => ({
         */
         childClick(child) {
             if (this.activeId !== child.newValue) {
-                this.performAction()
-                this.activeId = child.newValue
-                this.performAction()
+                this.performAction(child.newValue)
                 this.$emit('input', this.activeId)
             }
         },
         /**
         * Activate next child and deactivate prev child
         */
-        performAction() {
+        performAction(newId) {
             const oldValue = this.activeId
             const oldTab = oldValue !== undefined && oldValue !== null
                 ? this.childItems.filter((i) => i.newValue === oldValue)[0] : this.items[0]
+            this.activeId = newId
             if (oldTab && this.activeItem) {
                 oldTab.deactivate(this.activeItem.index)
                 this.activeItem.activate(oldTab.index)


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #241 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## fixed problems

- `oldTab` in `performAction()` always was the `activeItem`, so the index was always the same in `deactivate()`/`activate()` and therefor transistion name always `slide-prev`
- `performAction()` was always called 4 times (2x `childClick()`, 2x `modelValue()`-watcher 
