### PR TITLE
Fixes more null errors

### DIFF
--- a/packages/oruga-next/src/utils/FormElementMixin.ts
+++ b/packages/oruga-next/src/utils/FormElementMixin.ts
@@ -105,7 +105,7 @@ export default defineComponent({
 		 */
 		focus() {
 			const el = this.getElement();
-			if (el === undefined) return;
+			if (!el) return;
 
 			this.$nextTick(() => {
 				if (el) el.focus();
@@ -167,7 +167,7 @@ export default defineComponent({
 			if (!this.useHtml5Validation) return;
 
 			const el = this.getElement();
-			if (el === undefined) return;
+			if (!el) return;
 
 			if (!el.checkValidity()) {
 				this.setInvalid();


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

This PR fixes a null pointer exception: 

```
FormElementMixin-6fb41465.js:167 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'checkValidity')
    at Proxy.checkHtml5Validity (FormElementMixin-6fb41465.js:167)
    at Proxy.<anonymous> (Autocomplete-aa443bda.js:614)
```

I have also fixed other errors in this file by searching for `=== undefined`

## Proposed Changes

- change all `x === undefined` to `!x`
