### PR TITLE
fix(carousel): check event in dragEnd #264

### DIFF
--- a/packages/oruga-next/src/components/carousel/Carousel.vue
+++ b/packages/oruga-next/src/components/carousel/Carousel.vue
@@ -432,7 +432,7 @@ export default defineComponent({
             }
             this.delta = 0
             this.dragX = false
-            if (event.touches) {
+            if (event && event.touches) {
                 this.startTimer()
             }
             window.removeEventListener(this.touch ? 'touchmove' : 'mousemove', this.dragMove)

--- a/packages/oruga/src/components/carousel/Carousel.vue
+++ b/packages/oruga/src/components/carousel/Carousel.vue
@@ -428,7 +428,7 @@ export default {
             }
             this.delta = 0
             this.dragX = false
-            if (event.touches) {
+            if (event && event.touches) {
                 this.startTimer()
             }
             window.removeEventListener(this.touch ? 'touchmove' : 'mousemove', this.dragMove)


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #264 

## Proposed Changes

- Check `event` in Carousel dragEnd method before using it
