### PR TITLE
build: use `.mjs` extension for built esm files

### DIFF
--- a/packages/oruga-next/package.json
+++ b/packages/oruga-next/package.json
@@ -6,7 +6,7 @@
   "author": "Walter Tommasi <tommsi20@gmail.com>",
   "license": "MIT",
   "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "module": "dist/esm/index.mjs",
   "unpkg": "dist/oruga.min.js",
   "typings": "types/index.d.ts",
   "files": [

--- a/packages/oruga-next/rollup.config.js
+++ b/packages/oruga-next/rollup.config.js
@@ -55,7 +55,9 @@ export default () => {
             external: ['vue'],
             output: {
                 format: 'esm',
-                dir: `dist/esm`
+                dir: `dist/esm`,
+                entryFileNames: '[name].mjs',
+                chunkFileNames: '[name]-[hash].mjs',
             },
             plugins: [
                 node({
@@ -119,7 +121,7 @@ export default () => {
             external: ['vue'],
             output: {
                 format: 'esm',
-                file: 'dist/oruga.esm.js',
+                file: 'dist/oruga.mjs',
                 banner: bannerTxt
             },
             plugins: [
@@ -139,7 +141,7 @@ export default () => {
     if (process.env.MINIFY === 'true') {
         config = config.filter((c) => !!c.output.file)
         config.forEach((c) => {
-            c.output.file = c.output.file.replace(/\.js/g, '.min.js')
+            c.output.file = c.output.file.replace(/\.m?js/g, r => `.min${r}`)
             c.plugins.push(terser({
                 output: {
                     comments: '/^!/'


### PR DESCRIPTION
This PR (which will be a breaking change) changes the file extension for esm builds to `.mjs` to enable native node esm imports (for frameworks like nuxt 3).