### PR TITLE
[rfc] chore(dropdown): Add a property to configure dropdown/autocomplete menu tag

### DIFF
--- a/packages/oruga-next/src/components/autocomplete/Autocomplete.spec.js
+++ b/packages/oruga-next/src/components/autocomplete/Autocomplete.spec.js
@@ -213,4 +213,10 @@ describe('OAutocomplete', () => {
 
         expect(subject).toBeFalsy()
     })
+
+    it('has configurable menu and item tags', () => {
+        wrapper.setProps({menuTag: 'ul', itemTag: 'li'})
+        wrapper.find('ul.o-acp__menu').exists()
+        wrapper.find('li.o-acp__item').exists()
+    })
 })

--- a/packages/oruga-next/src/components/autocomplete/Autocomplete.vue
+++ b/packages/oruga-next/src/components/autocomplete/Autocomplete.vue
@@ -29,11 +29,13 @@
         <transition :name="animation">
             <div
                 :class="menuClasses"
+                :is="menuTag"
                 v-show="isActive && (!isEmpty || $slots.empty || $slots.header || $slots.footer)"
                 :style="menuStyle"
                 ref="dropdown">
                 <div
                     v-if="$slots.header"
+                    :is="itemTag"
                     ref="header"
                     role="button"
                     :tabindex="0"
@@ -44,6 +46,7 @@
                 <template v-for="(element, groupindex) in computedData">
                     <div
                         v-if="element.group"
+                        :is="itemTag"
                         :key="groupindex + 'group'"
                         :class="itemGroupClasses">
                         <slot
@@ -58,6 +61,7 @@
                     <div
                         v-for="(option, index) in element.items"
                         :key="groupindex + ':' + index"
+                        :is="itemTag"
                         :class="itemOptionClasses(option)"
                         @click.stop="setSelected(option, !keepOpen, $event)"
                         :ref="setItemRef"
@@ -73,11 +77,13 @@
                 </template>
                 <div
                     v-if="isEmpty && $slots.empty"
+                    :is="itemTag"
                     :class="itemEmptyClasses">
                     <slot name="empty" />
                 </div>
                 <div
                     v-if="$slots.footer"
+                    :is="itemTag"
                     ref="footer"
                     role="button"
                     :tabindex="0"
@@ -188,6 +194,24 @@ export default defineComponent({
         type: {
             type: String,
             default: 'text'
+        },
+        /**
+         * Menu tag name
+         */
+        menuTag: {
+            type: String,
+            default: () => {
+                return getValueByPath(getOptions(), 'autocomplete.menuTag', 'div')
+            }
+        },
+        /**
+         * Menu item tag name
+         */
+        itemTag: {
+            type: String,
+            default: () => {
+                return getValueByPath(getOptions(), 'autocomplete.itemTag', 'div')
+            }
         },
         /** Trigger the select event for the first pre-selected option when clicking outside and <code>keep-first</code> is enabled */
         selectOnClickOutside: Boolean,

--- a/packages/oruga-next/src/components/dropdown/Dropdown.spec.js
+++ b/packages/oruga-next/src/components/dropdown/Dropdown.spec.js
@@ -215,4 +215,9 @@ describe('ODropdown', () => {
         expect(document.removeEventListener).toBeCalledWith('click', expect.any(Function))
         expect(document.removeEventListener).toBeCalledWith('keyup', expect.any(Function))
     })
+
+    it('has configurable menu tag', () => {
+        wrapper.setProps({menuTag: 'ul'})
+        wrapper.find('ul.o-drop__menu').exists()
+    })
 })

--- a/packages/oruga-next/src/components/dropdown/Dropdown.vue
+++ b/packages/oruga-next/src/components/dropdown/Dropdown.vue
@@ -30,6 +30,7 @@
             <div
                 v-show="(!disabled && (isActive || isHoverable)) || inline"
                 ref="dropdownMenu"
+                :is="menuTag"
                 :class="menuClasses"
                 :aria-hidden="!isActive"
                 :role="ariaRole"
@@ -190,6 +191,16 @@ export default defineComponent({
          * Append dropdown content to body
          */
         appendToBody: Boolean,
+        /**
+         * Dropdown menu tag name
+         */
+        menuTag: {
+            type: String,
+            default: () => {
+                return getValueByPath(getOptions(), 'dropdown.menuTag', 'div')
+            }
+        },
+
         /**
         * @ignore
         */

--- a/packages/oruga/src/components/autocomplete/Autocomplete.spec.js
+++ b/packages/oruga/src/components/autocomplete/Autocomplete.spec.js
@@ -282,5 +282,11 @@ describe('OAutocomplete', () => {
 
         expect(emitted['select-footer']).toBeTruthy()
         expect(emitted['select-footer']).toHaveLength(2)
+    }),
+
+    it('has configurable menu and item tags', () => {
+        wrapper.setProps({menuTag: 'ul', itemTag: 'li'})
+        wrapper.find('ul.o-acp__menu').exists()
+        wrapper.find('li.o-acp__item').exists()
     })
 })

--- a/packages/oruga/src/components/autocomplete/Autocomplete.vue
+++ b/packages/oruga/src/components/autocomplete/Autocomplete.vue
@@ -28,12 +28,14 @@
 
         <transition :name="animation">
             <div
+                :is="menuTag"
                 :class="menuClasses"
                 v-show="isActive && (!isEmpty || $slots.empty || $slots.header || $slots.footer)"
                 :style="menuStyle"
                 ref="dropdown">
                 <div
                     v-if="$slots.header"
+                    :is="itemTag"
                     ref="header"
                     role="button"
                     tabindex="0"
@@ -45,6 +47,7 @@
                     <div
                         v-if="element.group"
                         :key="groupindex + 'group'"
+                        :is="itemTag"
                         :class="itemGroupClasses">
                         <slot
                             v-if="$scopedSlots.group"
@@ -57,6 +60,7 @@
                     </div>
                     <div
                         v-for="(option, index) in element.items"
+                        :is="itemTag"
                         :key="groupindex + ':' + index"
                         :class="itemOptionClasses(option)"
                         @click.stop="setSelected(option, !keepOpen, $event)"
@@ -73,11 +77,13 @@
                 </template>
                 <div
                     v-if="isEmpty && $slots.empty"
+                    :is="itemTag"
                     :class="itemEmptyClasses">
                     <slot name="empty" />
                 </div>
                 <div
                     v-if="$slots.footer"
+                    :is="itemTag"
                     ref="footer"
                     role="button"
                     tabindex="0"
@@ -182,6 +188,24 @@ export default {
         type: {
             type: String,
             default: 'text'
+        },
+        /**
+         * Menu tag name
+         */
+        menuTag: {
+            type: String,
+            default: () => {
+                return getValueByPath(getOptions(), 'autocomplete.menuTag', 'div')
+            }
+        },
+        /**
+         * Menu item tag name
+         */
+        itemTag: {
+            type: String,
+            default: () => {
+                return getValueByPath(getOptions(), 'autocomplete.itemTag', 'div')
+            }
         },
         /** Trigger the select event for the first pre-selected option when clicking outside and <code>keep-first</code> is enabled */
         selectOnClickOutside: Boolean,

--- a/packages/oruga/src/components/dropdown/Dropdown.spec.js
+++ b/packages/oruga/src/components/dropdown/Dropdown.spec.js
@@ -215,4 +215,9 @@ describe('ODropdown', () => {
         expect(document.removeEventListener).toBeCalledWith('click', expect.any(Function))
         expect(document.removeEventListener).toBeCalledWith('keyup', expect.any(Function))
     })
+
+    it('has configurable menu tag', () => {
+        wrapper.setProps({menuTag: 'ul'})
+        wrapper.find('ul.o-drop__menu').exists()
+    })
 })

--- a/packages/oruga/src/components/dropdown/Dropdown.vue
+++ b/packages/oruga/src/components/dropdown/Dropdown.vue
@@ -30,6 +30,7 @@
             <div
                 v-show="(!disabled && (isActive || isHoverable)) || inline"
                 ref="dropdownMenu"
+                :is="menuTag"
                 :class="menuClasses"
                 :aria-hidden="!isActive"
                 :role="ariaRole"
@@ -184,6 +185,15 @@ export default {
         triggers: {
             type: Array,
             default: () => ['click']
+        },
+        /**
+         * Dropdown menu tag name
+         */
+        menuTag: {
+            type: String,
+            default: () => {
+                return getValueByPath(getOptions(), 'dropdown.menuTag', 'div')
+            }
         },
         /**
          * Append dropdown content to body


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

## Proposed Changes

- Add a `menuTag` property to the Dropdown component. It'll help me use Oruga with DaisyUI which require the dropdown to be a li
- Add a `menuTag` and `itemTag` to the Autocomplete component, for the very same reason

I need some guidante to write tests on this