### PR TITLE
Fix default property value functions

### DIFF
--- a/packages/oruga-next/src/components/carousel/Carousel.vue
+++ b/packages/oruga-next/src/components/carousel/Carousel.vue
@@ -99,7 +99,7 @@ export default defineComponent({
         },
         interval: {
             type: Number,
-            default: () => { getValueByPath(getOptions(), 'carousel.interval', 3500) }
+            default: () => { return getValueByPath(getOptions(), 'carousel.interval', 3500) }
         },
         hasDrag: {
             type: Boolean,

--- a/packages/oruga-next/src/utils/NoticeMixin.ts
+++ b/packages/oruga-next/src/utils/NoticeMixin.ts
@@ -14,14 +14,14 @@ export default {
         duration: {
             type: Number,
             default: () => {
-                getValueByPath(getOptions(), 'notification.duration', 1000)
+                return getValueByPath(getOptions(), 'notification.duration', 1000)
             }
         },
         /** If should queue with others notices (snackbar/toast/notification). */
         queue: {
             type: Boolean,
             default: () => {
-                getValueByPath(getOptions(), 'notification.noticeQueue', undefined)
+                return getValueByPath(getOptions(), 'notification.noticeQueue', undefined)
             }
         },
         /** Show the Notification indefinitely until it is dismissed when programmatically. */
@@ -48,7 +48,7 @@ export default {
         container: {
             type: String,
             default: () => {
-                getValueByPath(getOptions(), 'notification.containerElement', undefined)
+                return getValueByPath(getOptions(), 'notification.containerElement', undefined)
             }
         },
         /** Callback function to call after close (programmatically close or user canceled) */

--- a/packages/oruga/src/components/carousel/Carousel.vue
+++ b/packages/oruga/src/components/carousel/Carousel.vue
@@ -96,7 +96,7 @@ export default {
         },
         interval: {
             type: Number,
-            default: () => { getValueByPath(getOptions(), 'carousel.interval', 3500) }
+            default: () => { return getValueByPath(getOptions(), 'carousel.interval', 3500) }
         },
         hasDrag: {
             type: Boolean,

--- a/packages/oruga/src/utils/NoticeMixin.js
+++ b/packages/oruga/src/utils/NoticeMixin.js
@@ -14,7 +14,7 @@ export default {
         duration: {
             type: Number,
             default: () => {
-                getValueByPath(getOptions(), 'notification.duration', 1000)
+                return getValueByPath(getOptions(), 'notification.duration', 1000)
             }
         },
         /** If should queue with others notices (snackbar/toast/notification). */
@@ -48,7 +48,7 @@ export default {
         container: {
             type: String,
             default: () => {
-                getValueByPath(getOptions(), 'notification.containerElement', undefined)
+                return getValueByPath(getOptions(), 'notification.containerElement', undefined)
             }
         },
         /** Callback function to call after close (programmatically close or user canceled) */


### PR DESCRIPTION
Fixes default property functions that were not returning any value.

One example is the default "duration" for notifications to be undefined and thus causing notifications to  immediately dismiss.
