### PR TITLE
Add details-open to emits list

### DIFF
--- a/packages/oruga-next/src/components/table/Table.vue
+++ b/packages/oruga-next/src/components/table/Table.vue
@@ -363,7 +363,7 @@ export default defineComponent({
     emits: [
         'page-change', 'click', 'dblclick', 'contextmenu',
         'check', 'check-all', 'update:checkedRows',
-        'select', 'update:selected', 'filters-change', 'details-close', 'update:openedDetailed',
+        'select', 'update:selected', 'filters-change', 'details-open', 'details-close', 'update:openedDetailed',
         'mouseenter', 'mouseleave', 'sort', 'sorting-priority-removed',
         'dragstart', 'dragend', 'drop', 'dragleave', 'dragover', 'cell-click',
         'columndragstart', 'columndragend', 'columndrop', 'columndragleave', 'columndragover'


### PR DESCRIPTION
Adds details-open to the list of emits to remove Vue warning in console, because it was missing.

Fixes #319
