### PR TITLE
Correct bad link in index.md that caused vitepress to complain about a dead link

### DIFF
--- a/packages/docs-next/documentation/index.md
+++ b/packages/docs-next/documentation/index.md
@@ -409,7 +409,7 @@ createApp(...)
 
 ### Using CSS or SASS/SCSS variables
 
-You can easily customize Oruga using CSS or SASS/SCSS variables. Each component has its own variables, mostly of them with default values defined in the [base style](documentation/#base-style) (see [utilities/_variables.scss](https://github.com/oruga-ui/oruga/blob/master/packages/oruga/src/scss/utilities/_variables.scss)).
+You can easily customize Oruga using CSS or SASS/SCSS variables. Each component has its own variables, mostly of them with default values defined in the [base style](#base-style) (see [utilities/_variables.scss](https://github.com/oruga-ui/oruga/blob/master/packages/oruga/src/scss/utilities/_variables.scss)).
 
 To use *CSS variables* you have to import `oruga-full-vars.css` stylesheet
 


### PR DESCRIPTION
## Proposed Changes

- changes link in documentation/index.md to reference `#base-style` instead of `documentation/#base-style`.

Without this vitepress yelps that the there is a dead link
