### PR TITLE
fix(InjectedChildMixin): Fix throwing ReferenceError in case an actua…

### DIFF
--- a/packages/oruga-next/src/utils/InjectedChildMixin.ts
+++ b/packages/oruga-next/src/utils/InjectedChildMixin.ts
@@ -13,7 +13,7 @@ export default (parentItemName: string, flags: number = 0) => {
             parent: { from: 'o' + parentItemName }
         },
         created() {
-            this.newValue = defaultIfUndefined(this.value, this.parent._nextSequence())
+            this.newValue = defaultIfUndefined(this.value, this.parent && this.parent._nextSequence())
             if (!this.parent) {
                 if (!hasFlag(flags, optional)) {
                     throw new Error('You should wrap ' + this.$options.name + ' in a ' + parentItemName)


### PR DESCRIPTION
By the time we check this.parent for null we have already been triggering a
undefined property access.