### PR TITLE
feat(oruga, oruga-next): Export individual components

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,60 +70,69 @@ Latest ✔ | Latest ✔ | 10+ ✔ | Latest ✔ | 6.1+ ✔ | IE 11  ✔ |
 
 #### Vue 2
 
-Install Oruga
+1. Install Oruga.
 
 ```bash
 npm install @oruga-ui/oruga
 ```
 
-Then import the full bundle
+2. Import the components:
 
-```js
-import Vue from 'vue';
-import Oruga from '@oruga-ui/oruga';
-import '@oruga-ui/oruga/dist/oruga.css';
+ - To get started quickly, use `Oruga` to register all components:
 
-Vue.use(Oruga);
-```
-or individual components (tree shaking)
+    ```js
+    import Vue from 'vue';
+    import Oruga from '@oruga-ui/oruga';
+    import '@oruga-ui/oruga/dist/oruga.css';
+    
+    Vue.use(Oruga);
+    ```
 
-```js
-import Vue from 'vue';
-import { Field, Input } from '@oruga-ui/oruga';
-import '@oruga-ui/oruga/dist/oruga.css';
+ - To use tree shaking, either register component manually:
 
-Vue.use(Field);
-Vue.use(Input);
-```
+    ```js
+    import Vue from 'vue';
+    import { OField, OInput } from '@oruga-ui/oruga';
+    import '@oruga-ui/oruga/dist/oruga.css';
+    
+    Vue.component(OField);
+    Vue.component(OInput);
+    ```
+   
+ - or [import them in your SFC](https://v2.vuejs.org/v2/guide/components-registration.html#Local-Registration-in-a-Module-System).
 
 #### Vue 3
 
-Install Oruga
+1. Install Oruga.
 
 ```bash
 npm install @oruga-ui/oruga-next
 ```
 
-Then import the full bundle
+2. Import the components:
 
-```js
-import { createApp } from 'vue'
-import Oruga from '@oruga-ui/oruga-next';
-import '@oruga-ui/oruga-next/dist/oruga.css';
+- To get started quickly, use `Oruga` to register all components:
 
-createApp(...).use(Oruga);
-```
-or individual components (tree shaking)
+    ```js
+    import { createApp } from 'vue'
+    import Oruga from '@oruga-ui/oruga-next';
+    import '@oruga-ui/oruga-next/dist/oruga.css';
+    
+    createApp(...).use(Oruga);
+    ```
 
-```js
-import Vue from 'vue'
-import { Field, Input } from '@oruga-ui/oruga'
-import '@oruga-ui/oruga/dist/oruga.css'
+ - To use tree shaking, either register component manually:
 
-createApp(...)
-  .use(Field)
-  .use(Input)
-```
+    ```js
+    import Vue from 'vue'
+    import { OField, OInput } from '@oruga-ui/oruga'
+    import '@oruga-ui/oruga/dist/oruga.css'
+    
+    createApp(...)
+      .component(OField)
+      .component(OInput)
+    ```
+ - or [import them in your SFC](https://vuejs.org/guide/components/registration.html#local-registration).
 
 ### Customization
 

--- a/packages/docs-next/documentation/index.md
+++ b/packages/docs-next/documentation/index.md
@@ -69,12 +69,12 @@ createApp(...).use(Oruga);
 
 ```js
 import { createApp } from 'vue'
-import { Autocomplete, Sidebar } from '@oruga-ui/oruga-next'
+import { OAutocomplete, OSidebar } from '@oruga-ui/oruga-next'
 import '@oruga-ui/oruga-next/dist/oruga.css'
 
 createApp(...)
-  .use(Autocomplete)
-  .use(Sidebar)
+  .component(OAutocomplete)
+  .component(OSidebar)
 ```
 
 ## Nuxt module
@@ -158,11 +158,11 @@ If you use individual imports you can customize each compoment using `Config` pl
 
 ```js
 import { createApp } from 'vue'
-import { Autocomplete, Sidebar, Config } from '@oruga-ui/oruga-next';
+import { OAutocomplete, OSidebar, Config } from '@oruga-ui/oruga-next';
 
 createApp(...)
-    .use(Autocomplete);
-    .use(Sidebar);
+    .component(OAutocomplete)
+    .component(OSidebar)
     .use(Config, {
         autocomplete: {
             rootClass: 'myautocomplete-root',

--- a/packages/docs/documentation/README.md
+++ b/packages/docs/documentation/README.md
@@ -82,11 +82,11 @@ Vue.use(Oruga)
 
 ```js
 import Vue from 'vue'
-import { Autocomplete, Sidebar } from '@oruga-ui/oruga'
+import { OAutocomplete, OSidebar } from '@oruga-ui/oruga'
 import '@oruga-ui/oruga/dist/oruga.css'
 
-Vue.use(Autocomplete)
-Vue.use(Sidebar)
+Vue.component(OAutocomplete)
+Vue.component(OSidebar)
 ```
 
 ### Vue 3
@@ -130,12 +130,12 @@ createApp(...).use(Oruga);
 
 ```js
 import { createApp } from 'vue'
-import { Autocomplete, Sidebar } from '@oruga-ui/oruga-next'
+import { OAutocomplete, OSidebar } from '@oruga-ui/oruga-next'
 import '@oruga-ui/oruga-next/dist/oruga.css'
 
 createApp(...)
-  .use(Autocomplete)
-  .use(Sidebar)
+  .use(OAutocomplete)
+  .use(OSidebar)
 ```
 
 ## Nuxt module
@@ -233,11 +233,13 @@ With Oruga you can easily override existing components style appending one or mo
 
 You can add classes to a component using class properties (see [Autocomplete class props](/components/Autocomplete.html#class-props) for example)
 
+#### Adding classes from props
+
 ```vue
 <o-autocomplete root-class="myautocomplete-root" menu-class="myautocomplete-menu" item-class="myautocomplete-item" />
 ```
 
-Or globally 
+#### Adding classes globally
 
 ```js
 import Vue from 'vue';
@@ -254,14 +256,14 @@ Vue.use(Oruga, {
 });
 ```
 
-If you use individual imports you can customize each compoment using `Config` plugin.
+If you use individual imports you can customize each component using `Config` plugin.
 
 ```js
 import Vue from 'vue';
-import { Autocomplete, Sidebar, Config } from '@oruga-ui/oruga';
+import { OAutocomplete, OSidebar, Config } from '@oruga-ui/oruga';
 
-Vue.use(Autocomplete);
-Vue.use(Sidebar);
+Vue.component(OAutocomplete);
+Vue.component(OSidebar);
 Vue.use(Config, {
     autocomplete: {
         rootClass: 'myautocomplete-root',

--- a/packages/oruga-next/src/components/index.ts
+++ b/packages/oruga-next/src/components/index.ts
@@ -1,59 +1,28 @@
-import Autocomplete from './autocomplete'
-import Button from './button'
-import Carousel from './carousel'
-import Checkbox from './checkbox'
-import Collapse from './collapse'
-import Datepicker from './datepicker'
-import Datetimepicker from './datetimepicker'
-import Dropdown from './dropdown'
-import Field from './field'
-import Icon from './icon'
-import Input from './input'
-import Inputitems from './inputitems'
-import Loading from './loading'
-import Modal from './modal'
-import Notification from './notification'
-import Pagination from './pagination'
-import Radio from './radio'
-import Select from './select'
-import Skeleton from './skeleton'
-import Sidebar from './sidebar'
-import Slider from './slider'
-import Steps from './steps'
-import Switch from './switch'
-import Table from './table'
-import Tabs from './tabs'
-import Timepicker from './timepicker'
-import Tooltip from './tooltip'
-import Upload from './upload'
-
-export {
-    Autocomplete,
-    Button,
-    Carousel,
-    Checkbox,
-    Collapse,
-    Datepicker,
-    Datetimepicker,
-    Dropdown,
-    Field,
-    Icon,
-    Input,
-    Inputitems,
-    Loading,
-    Modal,
-    Notification,
-    Pagination,
-    Radio,
-    Select,
-    Skeleton,
-    Sidebar,
-    Slider,
-    Steps,
-    Switch,
-    Table,
-    Tabs,
-    Timepicker,
-    Tooltip,
-    Upload
-}
+export * from './autocomplete'
+export * from './button'
+export * from './carousel'
+export * from './checkbox'
+export * from './collapse'
+export * from './datepicker'
+export * from './datetimepicker'
+export * from './dropdown'
+export * from './field'
+export * from './icon'
+export * from './input'
+export * from './inputitems'
+export * from './loading'
+export * from './modal'
+export * from './notification'
+export * from './pagination'
+export * from './radio'
+export * from './select'
+export * from './skeleton'
+export * from './sidebar'
+export * from './slider'
+export * from './steps'
+export * from './switch'
+export * from './table'
+export * from './tabs'
+export * from './timepicker'
+export * from './tooltip'
+export * from './upload'

--- a/packages/oruga-next/src/components/plugins.ts
+++ b/packages/oruga-next/src/components/plugins.ts
@@ -1,0 +1,59 @@
+import Autocomplete from './autocomplete'
+import Button from './button'
+import Carousel from './carousel'
+import Checkbox from './checkbox'
+import Collapse from './collapse'
+import Datepicker from './datepicker'
+import Datetimepicker from './datetimepicker'
+import Dropdown from './dropdown'
+import Field from './field'
+import Icon from './icon'
+import Input from './input'
+import Inputitems from './inputitems'
+import Loading from './loading'
+import Modal from './modal'
+import Notification from './notification'
+import Pagination from './pagination'
+import Radio from './radio'
+import Select from './select'
+import Skeleton from './skeleton'
+import Sidebar from './sidebar'
+import Slider from './slider'
+import Steps from './steps'
+import Switch from './switch'
+import Table from './table'
+import Tabs from './tabs'
+import Timepicker from './timepicker'
+import Tooltip from './tooltip'
+import Upload from './upload'
+
+export {
+    Autocomplete,
+    Button,
+    Carousel,
+    Checkbox,
+    Collapse,
+    Datepicker,
+    Datetimepicker,
+    Dropdown,
+    Field,
+    Icon,
+    Input,
+    Inputitems,
+    Loading,
+    Modal,
+    Notification,
+    Pagination,
+    Radio,
+    Select,
+    Skeleton,
+    Sidebar,
+    Slider,
+    Steps,
+    Switch,
+    Table,
+    Tabs,
+    Timepicker,
+    Tooltip,
+    Upload
+}

--- a/packages/oruga-next/src/index.ts
+++ b/packages/oruga-next/src/index.ts
@@ -1,6 +1,6 @@
 import { App } from 'vue'
 
-import * as components from './components'
+import * as plugins from './components/plugins'
 
 import { merge } from './utils/helpers'
 import { setOptions, setVueInstance, Programmatic as ConfigProgrammatic, getOptions } from './utils/config'
@@ -13,8 +13,8 @@ const Oruga = {
         const defaultConfig = getOptions()
         setOptions(merge(defaultConfig, options, true))
         // Components
-        for (const componentKey in components) {
-            registerPlugin(app, (components as any)[componentKey])
+        for (const componentKey in plugins) {
+            registerPlugin(app, (plugins as any)[componentKey])
         }
         // Config component
         registerComponentProgrammatic(app, 'config', ConfigProgrammatic)
@@ -23,8 +23,10 @@ const Oruga = {
 
 export default Oruga
 
-// export all components as vue plugin
+// export all vue components
 export * from './components'
+// export all components as vue plugin
+export * from './components/plugins'
 // export programmatic components
 export { LoadingProgrammatic } from './components/loading'
 export { ModalProgrammatic } from './components/modal'

--- a/packages/oruga/src/components/index.js
+++ b/packages/oruga/src/components/index.js
@@ -1,61 +1,29 @@
-import Autocomplete from './autocomplete'
-import Button from './button'
-import Carousel from './carousel'
-import Checkbox from './checkbox'
-import Collapse from './collapse'
-import Datepicker from './datepicker'
-import Datetimepicker from './datetimepicker'
-import Dropdown from './dropdown'
-import Field from './field'
-import Icon from './icon'
-import Input from './input'
-import Inputitems from './inputitems'
-import Loading from './loading'
-import Notification from './notification'
-import NotificationNotice from './notification'
-import Modal from './modal'
-import Pagination from './pagination'
-import Radio from './radio'
-import Select from './select'
-import Skeleton from './skeleton'
-import Sidebar from './sidebar'
-import Slider from './slider'
-import Steps from './steps'
-import Switch from './switch'
-import Table from './table'
-import Tabs from './tabs'
-import Timepicker from './timepicker'
-import Tooltip from './tooltip'
-import Upload from './upload'
-
-export {
-    Autocomplete,
-    Button,
-    Carousel,
-    Checkbox,
-    Collapse,
-    Datepicker,
-    Datetimepicker,
-    Dropdown,
-    Field,
-    Icon,
-    Input,
-    Inputitems,
-    Loading,
-    Modal,
-    Notification,
-    NotificationNotice,
-    Pagination,
-    Radio,
-    Select,
-    Skeleton,
-    Sidebar,
-    Slider,
-    Steps,
-    Switch,
-    Table,
-    Tabs,
-    Timepicker,
-    Tooltip,
-    Upload
-}
+export * from './autocomplete'
+export * from './button'
+export * from './carousel'
+export * from './checkbox'
+export * from './collapse'
+export * from './datepicker'
+export * from './datetimepicker'
+export * from './dropdown'
+export * from './field'
+export * from './icon'
+export * from './input'
+export * from './inputitems'
+export * from './loading'
+export * from './notification'
+export * from './notification'
+export * from './modal'
+export * from './pagination'
+export * from './radio'
+export * from './select'
+export * from './skeleton'
+export * from './sidebar'
+export * from './slider'
+export * from './steps'
+export * from './switch'
+export * from './table'
+export * from './tabs'
+export * from './timepicker'
+export * from './tooltip'
+export * from './upload'

--- a/packages/oruga/src/components/plugins.js
+++ b/packages/oruga/src/components/plugins.js
@@ -1,0 +1,61 @@
+import Autocomplete from './autocomplete'
+import Button from './button'
+import Carousel from './carousel'
+import Checkbox from './checkbox'
+import Collapse from './collapse'
+import Datepicker from './datepicker'
+import Datetimepicker from './datetimepicker'
+import Dropdown from './dropdown'
+import Field from './field'
+import Icon from './icon'
+import Input from './input'
+import Inputitems from './inputitems'
+import Loading from './loading'
+import Notification from './notification'
+import NotificationNotice from './notification'
+import Modal from './modal'
+import Pagination from './pagination'
+import Radio from './radio'
+import Select from './select'
+import Skeleton from './skeleton'
+import Sidebar from './sidebar'
+import Slider from './slider'
+import Steps from './steps'
+import Switch from './switch'
+import Table from './table'
+import Tabs from './tabs'
+import Timepicker from './timepicker'
+import Tooltip from './tooltip'
+import Upload from './upload'
+
+export {
+    Autocomplete,
+    Button,
+    Carousel,
+    Checkbox,
+    Collapse,
+    Datepicker,
+    Datetimepicker,
+    Dropdown,
+    Field,
+    Icon,
+    Input,
+    Inputitems,
+    Loading,
+    Modal,
+    Notification,
+    NotificationNotice,
+    Pagination,
+    Radio,
+    Select,
+    Skeleton,
+    Sidebar,
+    Slider,
+    Steps,
+    Switch,
+    Table,
+    Tabs,
+    Timepicker,
+    Tooltip,
+    Upload
+}

--- a/packages/oruga/src/index.js
+++ b/packages/oruga/src/index.js
@@ -1,4 +1,4 @@
-import * as components from './components'
+import * as plugins from './components/plugins'
 
 import { merge } from './utils/helpers'
 import { setOptions, setVueInstance, Programmatic as ConfigProgrammatic, getOptions } from './utils/config'
@@ -11,8 +11,8 @@ const Oruga = {
         const defaultConfig = getOptions()
         setOptions(merge(defaultConfig, options, true))
         // Components
-        for (const componentKey in components) {
-            registerPlugin(Vue, components[componentKey])
+        for (const componentKey in plugins) {
+            registerPlugin(Vue, plugins[componentKey])
         }
         // Config component
         registerComponentProgrammatic(Vue, 'config', ConfigProgrammatic)
@@ -23,8 +23,10 @@ use(Oruga)
 
 export default Oruga
 
-// export all components as vue plugin
+// export all vue components
 export * from './components'
+// export all components as vue plugin
+export * from './components/plugins'
 // export programmatic components
 export { LoadingProgrammatic } from './components/loading'
 export { ModalProgrammatic } from './components/modal'


### PR DESCRIPTION
It allows components to be registered locally instead of globally (see [1]).
Some IDE can automatically insert these imports which greatly reduces the hassle
of using tree shaking.

It doesn't handle CSS imports yet, but the old implementation did not either.
A promising solution is to use a bundler plugin, which is adopted by Element
Plus [2].

I'm keeping the old, plugin based API for backward compatibility. Eventually
we can remove it in favor of direct imports.

[1]: https://vuejs.org/guide/components/registration.html#local-registration
[2]: https://github.com/element-plus/unplugin-element-plus