### PR TITLE
Handle non existing window.matchMedia

### DIFF
--- a/packages/oruga-next/src/utils/MatchMediaMixin.ts
+++ b/packages/oruga-next/src/utils/MatchMediaMixin.ts
@@ -29,13 +29,19 @@ export default defineComponent({
                 width = getValueByPath(config, `${this.$options.configField}.mobileBreakpoint`, defaultWidth)
             }
             this.matchMediaRef = window.matchMedia(`(max-width: ${width})`)
-            this.isMatchMedia = this.matchMediaRef?.matches
-            this.matchMediaRef?.addListener(this.onMatchMedia, false)
+            if (this.matchMediaRef) {
+                this.isMatchMedia = this.matchMediaRef.matches
+                this.matchMediaRef.addListener(this.onMatchMedia, false)
+            } else {
+                this.isMatchMedia = false
+            }
         }
     },
     beforeUnmount() {
         if (typeof window !== 'undefined') {
-            this.matchMediaRef.removeListener(this.checkMatchMedia)
+            if (this.matchMediaRef) {
+                this.matchMediaRef.removeListener(this.checkMatchMedia)
+            }
         }
     }
 })

--- a/packages/oruga-next/src/utils/MatchMediaMixin.ts
+++ b/packages/oruga-next/src/utils/MatchMediaMixin.ts
@@ -29,8 +29,8 @@ export default defineComponent({
                 width = getValueByPath(config, `${this.$options.configField}.mobileBreakpoint`, defaultWidth)
             }
             this.matchMediaRef = window.matchMedia(`(max-width: ${width})`)
-            this.isMatchMedia = this.matchMediaRef.matches
-            this.matchMediaRef.addListener(this.onMatchMedia, false)
+            this.isMatchMedia = this.matchMediaRef?.matches
+            this.matchMediaRef?.addListener(this.onMatchMedia, false)
         }
     },
     beforeUnmount() {

--- a/packages/oruga/src/utils/MatchMediaMixin.js
+++ b/packages/oruga/src/utils/MatchMediaMixin.js
@@ -28,8 +28,8 @@ export default {
                 width = getValueByPath(config, `${this.$options.configField}.mobileBreakpoint`, defaultWidth)
             }
             this.matchMediaRef = window.matchMedia(`(max-width: ${width})`)
-            this.isMatchMedia = this.matchMediaRef.matches
-            this.matchMediaRef.addListener(this.onMatchMedia, false)
+            this.isMatchMedia = this.matchMediaRef?.matches
+            this.matchMediaRef?.addListener(this.onMatchMedia, false)
         }
     },
     beforeDestroy() {

--- a/packages/oruga/src/utils/MatchMediaMixin.js
+++ b/packages/oruga/src/utils/MatchMediaMixin.js
@@ -28,13 +28,19 @@ export default {
                 width = getValueByPath(config, `${this.$options.configField}.mobileBreakpoint`, defaultWidth)
             }
             this.matchMediaRef = window.matchMedia(`(max-width: ${width})`)
-            this.isMatchMedia = this.matchMediaRef?.matches
-            this.matchMediaRef?.addListener(this.onMatchMedia, false)
+            if (this.matchMediaRef) {
+                this.isMatchMedia = this.matchMediaRef.matches
+                this.matchMediaRef.addListener(this.onMatchMedia, false)
+            } else {
+                this.isMatchMedia = false
+            }
         }
     },
     beforeDestroy() {
         if (typeof window !== 'undefined') {
-            this.matchMediaRef.removeListener(this.checkMatchMedia)
+            if (this.matchMediaRef) {
+                this.matchMediaRef.removeListener(this.checkMatchMedia)
+            }
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes
Handle `window.matchMedia` being undefined properly. This can happen when it's hard to mock environment (jest/jsdom) like done in d0262fd675f51d5262737ec1ec3fc0f481db776b.

This should be harmless.