### PR TITLE
Fix/imports not used as values

### DIFF
--- a/packages/oruga-next/src/components/autocomplete/index.ts
+++ b/packages/oruga-next/src/components/autocomplete/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Autocomplete from './Autocomplete.vue'
 

--- a/packages/oruga-next/src/components/button/index.ts
+++ b/packages/oruga-next/src/components/button/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Button from './Button.vue'
 

--- a/packages/oruga-next/src/components/carousel/index.ts
+++ b/packages/oruga-next/src/components/carousel/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Carousel from './Carousel.vue'
 import CarouselItem from './CarouselItem.vue'

--- a/packages/oruga-next/src/components/checkbox/index.ts
+++ b/packages/oruga-next/src/components/checkbox/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Checkbox from './Checkbox.vue'
 

--- a/packages/oruga-next/src/components/collapse/index.ts
+++ b/packages/oruga-next/src/components/collapse/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Collapse from './Collapse.vue'
 

--- a/packages/oruga-next/src/components/datepicker/Datepicker.vue
+++ b/packages/oruga-next/src/components/datepicker/Datepicker.vue
@@ -238,7 +238,8 @@
 </template>
 
 <script lang="ts">
-import { App, defineComponent, PropType } from 'vue'
+import type { App, PropType } from 'vue'
+import { defineComponent } from 'vue'
 
 import FormElementMixin from '../../utils/FormElementMixin'
 import BaseComponentMixin from '../../utils/BaseComponentMixin'

--- a/packages/oruga-next/src/components/datepicker/index.ts
+++ b/packages/oruga-next/src/components/datepicker/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Datepicker from './Datepicker.vue'
 

--- a/packages/oruga-next/src/components/datetimepicker/index.ts
+++ b/packages/oruga-next/src/components/datetimepicker/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Datetimepicker from './Datetimepicker.vue'
 

--- a/packages/oruga-next/src/components/dropdown/index.ts
+++ b/packages/oruga-next/src/components/dropdown/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Dropdown from './Dropdown.vue'
 import DropdownItem from './DropdownItem.vue'

--- a/packages/oruga-next/src/components/field/index.ts
+++ b/packages/oruga-next/src/components/field/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Field from './Field.vue'
 

--- a/packages/oruga-next/src/components/icon/index.ts
+++ b/packages/oruga-next/src/components/icon/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Icon from './Icon.vue'
 

--- a/packages/oruga-next/src/components/input/index.ts
+++ b/packages/oruga-next/src/components/input/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Input from './Input.vue'
 

--- a/packages/oruga-next/src/components/inputitems/index.ts
+++ b/packages/oruga-next/src/components/inputitems/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Inputitems from './Inputitems.vue'
 

--- a/packages/oruga-next/src/components/loading/index.ts
+++ b/packages/oruga-next/src/components/loading/index.ts
@@ -1,4 +1,5 @@
-import { App, ComponentPropsOptions, createVNode, Plugin, render } from 'vue'
+import type { App, ComponentPropsOptions, Plugin } from 'vue'
+import { createVNode, render } from 'vue'
 
 import Loading from './Loading.vue'
 

--- a/packages/oruga-next/src/components/modal/index.ts
+++ b/packages/oruga-next/src/components/modal/index.ts
@@ -1,4 +1,5 @@
-import { App, createVNode, DefineComponent, Plugin, render } from 'vue'
+import type { App, DefineComponent, Plugin } from 'vue'
+import { createVNode, render } from 'vue'
 
 import Modal from './Modal.vue'
 

--- a/packages/oruga-next/src/components/notification/index.ts
+++ b/packages/oruga-next/src/components/notification/index.ts
@@ -8,8 +8,8 @@ import { VueInstance } from '../../utils/config'
 import { registerComponent, registerComponentProgrammatic } from '../../utils/plugins'
 import InstanceRegistry from "../..//utils/InstanceRegistry"
 
-import { App, createVNode, DefineComponent, Plugin, render } from 'vue'
-
+import type { App, DefineComponent, Plugin } from 'vue'
+import { createVNode, render } from 'vue'
 
 let localVueInstance: App
 

--- a/packages/oruga-next/src/components/pagination/index.ts
+++ b/packages/oruga-next/src/components/pagination/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Pagination from './Pagination.vue'
 import PaginationButton from './PaginationButton.vue'

--- a/packages/oruga-next/src/components/radio/index.ts
+++ b/packages/oruga-next/src/components/radio/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Radio from './Radio.vue'
 

--- a/packages/oruga-next/src/components/select/index.ts
+++ b/packages/oruga-next/src/components/select/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Select from './Select.vue'
 

--- a/packages/oruga-next/src/components/sidebar/index.ts
+++ b/packages/oruga-next/src/components/sidebar/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Sidebar from './Sidebar.vue'
 

--- a/packages/oruga-next/src/components/skeleton/index.ts
+++ b/packages/oruga-next/src/components/skeleton/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Skeleton from './Skeleton.vue'
 

--- a/packages/oruga-next/src/components/slider/index.ts
+++ b/packages/oruga-next/src/components/slider/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Slider from './Slider.vue'
 import SliderTick from './SliderTick.vue'

--- a/packages/oruga-next/src/components/steps/index.ts
+++ b/packages/oruga-next/src/components/steps/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Steps from './Steps.vue'
 import StepItem from './StepItem.vue'

--- a/packages/oruga-next/src/components/switch/index.ts
+++ b/packages/oruga-next/src/components/switch/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Switch from './Switch.vue'
 

--- a/packages/oruga-next/src/components/table/index.ts
+++ b/packages/oruga-next/src/components/table/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Table from './Table.vue'
 import TableColumn from './TableColumn.vue'

--- a/packages/oruga-next/src/components/tabs/index.ts
+++ b/packages/oruga-next/src/components/tabs/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Tabs from './Tabs.vue'
 import TabItem from './TabItem.vue'

--- a/packages/oruga-next/src/components/timepicker/index.ts
+++ b/packages/oruga-next/src/components/timepicker/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Timepicker from './Timepicker.vue'
 

--- a/packages/oruga-next/src/components/tooltip/index.ts
+++ b/packages/oruga-next/src/components/tooltip/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Tooltip from './Tooltip.vue'
 

--- a/packages/oruga-next/src/components/upload/index.ts
+++ b/packages/oruga-next/src/components/upload/index.ts
@@ -1,4 +1,4 @@
-import { App, Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
 
 import Upload from './Upload.vue'
 

--- a/packages/oruga-next/src/index.ts
+++ b/packages/oruga-next/src/index.ts
@@ -1,4 +1,4 @@
-import { App } from 'vue'
+import type { App } from 'vue'
 
 import * as plugins from './components/plugins'
 

--- a/packages/oruga-next/src/utils/BaseComponentMixin.ts
+++ b/packages/oruga-next/src/utils/BaseComponentMixin.ts
@@ -1,4 +1,5 @@
-import { ComponentOptions, defineComponent } from 'vue';
+import type { ComponentOptions } from 'vue';
+import { defineComponent } from 'vue';
 import { getOptions } from './config'
 import { getValueByPath, blankIfUndefined, endsWith } from './helpers'
 

--- a/packages/oruga-next/src/utils/InjectedChildMixin.ts
+++ b/packages/oruga-next/src/utils/InjectedChildMixin.ts
@@ -1,5 +1,5 @@
-import { defineComponent, DefineComponent } from 'vue'
-import { defaultIfUndefined, hasFlag } from './helpers'
+import type { DefineComponent } from 'vue';
+import { defineComponent } from 'vue';
 
 const sorted = 1
 const optional = 2

--- a/packages/oruga-next/src/utils/ProviderParentMixin.ts
+++ b/packages/oruga-next/src/utils/ProviderParentMixin.ts
@@ -1,4 +1,6 @@
-import { defineComponent, DefineComponent } from 'vue'
+import type { DefineComponent } from 'vue';
+import { defineComponent } from 'vue';
+
 import { hasFlag } from './helpers'
 
 const items = 1

--- a/packages/oruga-next/src/utils/SlotComponent.ts
+++ b/packages/oruga-next/src/utils/SlotComponent.ts
@@ -1,4 +1,5 @@
-import { DefineComponent, defineComponent, h } from 'vue'
+import type { DefineComponent } from 'vue';
+import { defineComponent, h } from 'vue';
 
 export default defineComponent({
     name: 'OSlotComponent',

--- a/packages/oruga-next/src/utils/TimepickerMixin.ts
+++ b/packages/oruga-next/src/utils/TimepickerMixin.ts
@@ -1,4 +1,6 @@
-import { App, defineComponent } from 'vue'
+import type { App } from 'vue'
+import { defineComponent } from 'vue';
+
 import { getOptions } from './config'
 import FormElementMixin from './FormElementMixin'
 import { getValueByPath, isMobile, matchWithGroups } from './helpers'
@@ -584,7 +586,7 @@ export default defineComponent({
             }
             return disabled
         },
-        
+
         isMeridienDisabled(meridienString){
             const offset = meridienString == "AM" ? 0 : 12;
             for(let i = 0; i < 12; i++){

--- a/packages/oruga-next/src/utils/config.ts
+++ b/packages/oruga-next/src/utils/config.ts
@@ -1,5 +1,6 @@
-import { App } from "vue"
-import { merge } from "./helpers"
+import type { App } from 'vue'
+
+import { merge } from './helpers';
 
 let config = {
     iconPack: 'mdi',

--- a/packages/oruga-next/src/utils/plugins.ts
+++ b/packages/oruga-next/src/utils/plugins.ts
@@ -1,5 +1,4 @@
-
-import { App, DefineComponent, Plugin } from 'vue'
+import type { App, DefineComponent, Plugin } from 'vue'
 import { useProgrammatic } from './useProgrammatic'
 
 export const registerPlugin = (app: App, plugin: Plugin) => {

--- a/packages/oruga-next/tsconfig.json
+++ b/packages/oruga-next/tsconfig.json
@@ -13,6 +13,7 @@
     "noImplicitThis": false,
     "noImplicitAny": false,
     "strictNullChecks": false,
+    "importsNotUsedAsValues": "error",
     "baseUrl": ".",
     "types": [],
     "paths": {


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

## Issue
Attempt to use **oruga-next** with vite@3 failing due to `Uncaught SyntaxError: ambiguous indirect export: App`
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- split type and value imports
- add `importsNotUsedAsValues` to the tsconfig.json

