### PR TITLE
fix: make controls respond to the `invalid` event

### DIFF
--- a/packages/docs-next/components/Autocomplete.md
+++ b/packages/docs-next/components/Autocomplete.md
@@ -73,6 +73,7 @@ title: Autocomplete
 | blur              |                                                                              |
 | focus             |                                                                              |
 | update:modelValue |                                                                              |
+| invalid           |                                                                              |
 | select            | **selected** `Object` - selected option<br/>**event** `Event` - native event |
 | infinite-scroll   |                                                                              |
 | typing            |                                                                              |

--- a/packages/docs-next/components/Datepicker.md
+++ b/packages/docs-next/components/Datepicker.md
@@ -91,6 +91,7 @@ title: Datepicker
 | range-end         |            |
 | blur              |            |
 | focus             |            |
+| invalid           |            |
 | update:modelValue |            |
 | change-month      |            |
 | change-year       |            |

--- a/packages/docs-next/components/Datetimepicker.md
+++ b/packages/docs-next/components/Datetimepicker.md
@@ -68,6 +68,7 @@ title: Datetimepicker
 | change-year       |            |
 | blur              |            |
 | focus             |            |
+| invalid           |            |
 | update:modelValue |            |
 
 ## Slots

--- a/packages/docs-next/components/Input.md
+++ b/packages/docs-next/components/Input.md
@@ -56,6 +56,7 @@ title: Input
 | ----------------- | ---------- | ----------- |
 | blur              |            |
 | focus             |            |
+| invalid           |            |
 | update:modelValue |            |
 | icon-click        |            |
 | icon-right-click  |            |

--- a/packages/docs-next/components/Inputitems.md
+++ b/packages/docs-next/components/Inputitems.md
@@ -71,6 +71,7 @@ title: Inputitems
 | icon-right-click  |            |
 | blur              |            |
 | focus             |            |
+| invalid           |            |
 | update:modelValue |            |
 | add               |            |
 | remove            |            |

--- a/packages/docs-next/components/Select.md
+++ b/packages/docs-next/components/Select.md
@@ -51,6 +51,7 @@ title: Select
 | ----------------- | ---------- | ----------- |
 | blur              |            |
 | focus             |            |
+| invalid           |            |
 | update:modelValue |            |
 
 ## Slots

--- a/packages/docs-next/components/Timepicker.md
+++ b/packages/docs-next/components/Timepicker.md
@@ -69,6 +69,7 @@ title: Timepicker
 | ----------------- | ---------- | ----------- |
 | blur              |            |
 | focus             |            |
+| invalid           |            |
 | update:modelValue |            |
 
 ## Slots

--- a/packages/docs-next/documentation/index.md
+++ b/packages/docs-next/documentation/index.md
@@ -523,12 +523,13 @@ Take a look at the [official TailwindCSS + Oruga example](https://github.com/oru
 
 ## Global Props
 
-| Field              | Description                                                   | Default |
-| ------------------ | ------------------------------------------------------------- | ------- |
-| statusIcon         | Show status icon using field and variant prop                 | true    |
-| statusVariantIcon  | Default mapping of variant and icon name                      | <code style='white-space: nowrap; padding: 0;'>{<br>&nbsp;&nbsp;'success': 'check',<br>&nbsp;&nbsp;'danger': 'alert-circle',<br>&nbsp;&nbsp;'info':'information', <br>&nbsp;&nbsp;'warning': 'alert'<br>} </code>  |
-| useHtml5Validation | Default form components use-html5-validation attribute        | true    |
-| iconPack           | Icon pack used internally and on the Icon component attribute | 'mdi'   |
+| Field              | Description                                                                                                                                                                                  | Default |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| statusIcon         | Show status icon using field and variant prop                                                                                                                                                | true    |
+| statusVariantIcon  | Default mapping of variant and icon name                                                                                                                                                     | <code style='white-space: nowrap; padding: 0;'>{<br>&nbsp;&nbsp;'success': 'check',<br>&nbsp;&nbsp;'danger': 'alert-circle',<br>&nbsp;&nbsp;'info':'information', <br>&nbsp;&nbsp;'warning': 'alert'<br>} </code> |
+| useHtml5Validation | Default form components use-html5-validation attribute                                                                                                                                       | true    |
+| iconPack           | Icon pack used internally and on the Icon component attribute                                                                                                                                | 'mdi'   |
+| reportInvalidInput | Callback function that allows for custom behavior when HTML constraint validation would visually report that a field is invalid. Takes the input and its parent field (if any) as arguments. | <code style='white-space: nowrap; padding: 0;'>null</code> |
 
 Take a look at each component docs to know all customizable fields/props by config.
 

--- a/packages/docs/components/Autocomplete.md
+++ b/packages/docs/components/Autocomplete.md
@@ -512,6 +512,7 @@ export default {
 | blur             |                                                                             |
 | focus            |                                                                             |
 | input            |                                                                             |
+| invalid           |                                                                              |
 | select           | **selected** `Object` - selected option<br>**event** `Event` - native event |
 | select-header    |                                                                             |
 | select-footer    |                                                                             |

--- a/packages/docs/components/Datepicker.md
+++ b/packages/docs/components/Datepicker.md
@@ -1030,6 +1030,7 @@ export default {
 | blur             |            |
 | focus            |            |
 | input            |            |
+| invalid          |            |
 | change-month     |            |
 | change-year      |            |
 | active-change    |            |

--- a/packages/docs/components/Datetimepicker.md
+++ b/packages/docs/components/Datetimepicker.md
@@ -246,6 +246,7 @@ export default {
 | blur             |            |
 | focus            |            |
 | input            |            |
+| invalid          |            |
 
 ## Slots
 

--- a/packages/docs/components/Input.md
+++ b/packages/docs/components/Input.md
@@ -280,6 +280,7 @@ export default {
 | blur       |            |
 | focus      |            |
 | input      |            |
+| invalid    |            |
 
 ## Style
 

--- a/packages/docs/components/Inputitems.md
+++ b/packages/docs/components/Inputitems.md
@@ -453,6 +453,7 @@ export default {
 | blur             |            |
 | focus            |            |
 | input            |            |
+| invalid          |            |
 | add              |            |
 | typing           |            |
 | remove           |            |

--- a/packages/docs/components/Select.md
+++ b/packages/docs/components/Select.md
@@ -311,6 +311,7 @@ export default {
 | blur       |            |
 | focus      |            |
 | input      |            |
+| invalid    |            |
 
 ## Slots
 

--- a/packages/docs/components/Timepicker.md
+++ b/packages/docs/components/Timepicker.md
@@ -331,6 +331,7 @@ export default {
 | blur       |            |
 | focus      |            |
 | input      |            |
+| invalid    |            |
 
 ## Slots
 

--- a/packages/docs/documentation/README.md
+++ b/packages/docs/documentation/README.md
@@ -613,12 +613,13 @@ Take a look at the [official TailwindCSS + Oruga example](https://github.com/oru
 
 ## Global Props
 
-| Field              | Description                                                   | Default |
-| ------------------ | ------------------------------------------------------------- | ------- |
-| statusIcon         | Show status icon using field and variant prop                 | true    |
-| statusVariantIcon  | Default mapping of variant and icon name                      | <code style='white-space: nowrap; padding: 0;'>{<br>&nbsp;&nbsp;'success': 'check',<br>&nbsp;&nbsp;'danger': 'alert-circle',<br>&nbsp;&nbsp;'info':'information', <br>&nbsp;&nbsp;'warning': 'alert'<br>} </code>  |
-| useHtml5Validation | Default form components use-html5-validation attribute        | true    |
-| iconPack           | Icon pack used internally and on the Icon component attribute | 'mdi'   |
+| Field              | Description                                                                                                                                                                                  | Default |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| statusIcon         | Show status icon using field and variant prop                                                                                                                                                | true    |
+| statusVariantIcon  | Default mapping of variant and icon name                                                                                                                                                     | <code style='white-space: nowrap; padding: 0;'>{<br>&nbsp;&nbsp;'success': 'check',<br>&nbsp;&nbsp;'danger': 'alert-circle',<br>&nbsp;&nbsp;'info':'information', <br>&nbsp;&nbsp;'warning': 'alert'<br>} </code> |
+| useHtml5Validation | Default form components use-html5-validation attribute                                                                                                                                       | true    |
+| iconPack           | Icon pack used internally and on the Icon component attribute                                                                                                                                | 'mdi'   |
+| reportInvalidInput | Callback function that allows for custom behavior when HTML constraint validation would visually report that a field is invalid. Takes the input and its parent field (if any) as arguments. | <code style='white-space: nowrap; padding: 0;'>null</code> |
 
 Take a look at each component docs to know all customizable fields/props by config.
 

--- a/packages/oruga-next/src/components/autocomplete/Autocomplete.vue
+++ b/packages/oruga-next/src/components/autocomplete/Autocomplete.vue
@@ -19,6 +19,7 @@
             @update:modelValue="onInput"
             @focus="focused"
             @blur="onBlur"
+            @invalid="onInvalid"
             @keydown="keydown"
             @keydown.up.prevent="keyArrows('up')"
             @keydown.down.prevent="keyArrows('down')"
@@ -120,7 +121,7 @@ export default defineComponent({
     },
     mixins: [BaseComponentMixin, FormElementMixin],
     inheritAttrs: false,
-    emits: ['update:modelValue', 'select', 'infinite-scroll', 'typing', 'focus', 'blur', 'icon-click', 'icon-right-click'],
+    emits: ['update:modelValue', 'select', 'infinite-scroll', 'typing', 'focus', 'blur', 'invalid', 'icon-click', 'icon-right-click'],
     props: {
         /** @model */
         modelValue: [Number, String],

--- a/packages/oruga-next/src/components/datepicker/Datepicker.vue
+++ b/packages/oruga-next/src/components/datepicker/Datepicker.vue
@@ -234,7 +234,8 @@
             :use-html5-validation="false"
             @change="onChangeNativePicker"
             @focus="onFocus"
-            @blur="onBlur"/>
+            @blur="onBlur"
+            @invalid="onInvalid" />
     </div>
 </template>
 
@@ -331,7 +332,7 @@ export default defineComponent({
             $datepicker: this
         }
     },
-    emits: ['update:modelValue', 'focus', 'blur', 'change-month', 'change-year', 'range-start', 'range-end', 'active-change', 'icon-right-click'],
+    emits: ['update:modelValue', 'focus', 'blur', 'invalid', 'change-month', 'change-year', 'range-start', 'range-end', 'active-change', 'icon-right-click'],
     props: {
         modelValue: {
             type: [Date, Array]

--- a/packages/oruga-next/src/components/datetimepicker/Datetimepicker.vue
+++ b/packages/oruga-next/src/components/datetimepicker/Datetimepicker.vue
@@ -73,7 +73,8 @@
         :use-html5-validation="useHtml5Validation"
         @change="onChangeNativePicker"
         @focus="onFocus"
-        @blur="onBlur"/>
+        @blur="onBlur"
+        @invalid="onInvalid" />
 </template>
 
 <script lang="ts">
@@ -103,7 +104,7 @@ export default defineComponent({
     configField: 'datetimepicker',
     mixins: [FormElementMixin, BaseComponentMixin],
     inheritAttrs: false,
-    emits: ['update:modelValue', 'change-year', 'change-month', 'icon-right-click', 'active-change'],
+    emits: ['update:modelValue', 'focus', 'blur', 'invalid', 'change-year', 'change-month', 'icon-right-click', 'active-change'],
     props: {
         modelValue: {
             type: Date

--- a/packages/oruga-next/src/components/input/Input.vue
+++ b/packages/oruga-next/src/components/input/Input.vue
@@ -11,7 +11,8 @@
             :value="computedValue"
             @input="onInput"
             @blur="onBlur"
-            @focus="onFocus">
+            @focus="onFocus"
+            @invalid="onInvalid" />
 
         <textarea
             v-else
@@ -23,6 +24,7 @@
             @input="onInput"
             @blur="onBlur"
             @focus="onFocus"
+            @invalid="onInvalid"
             :style="computedStyles"
             />
 
@@ -78,7 +80,7 @@ export default defineComponent({
     mixins: [BaseComponentMixin, FormElementMixin],
     configField: 'input',
     inheritAttrs: false,
-    emits: ['update:modelValue', 'icon-click', 'icon-right-click'],
+    emits: ['update:modelValue', 'input', 'focus', 'blur', 'invalid', 'icon-click', 'icon-right-click'],
     props: {
         /** @model */
         modelValue: [Number, String],

--- a/packages/oruga-next/src/components/inputitems/Inputitems.vue
+++ b/packages/oruga-next/src/components/inputitems/Inputitems.vue
@@ -48,6 +48,7 @@
                 @typing="onTyping"
                 @focus="onFocus"
                 @blur="customOnBlur"
+                @invalid="onInvalid"
                 @keydown="keydown"
                 @compositionstart="isComposing = true"
                 @compositionend="isComposing = false"
@@ -117,7 +118,7 @@ export default defineComponent({
     mixins: [FormElementMixin, BaseComponentMixin],
     inheritAttrs: false,
     configField: 'inputitems',
-    emits: ['update:modelValue', 'focus', 'blur', 'add', 'remove', 'typing', 'infinite-scroll', 'icon-right-click'],
+    emits: ['update:modelValue', 'focus', 'blur', 'invalid', 'add', 'remove', 'typing', 'infinite-scroll', 'icon-right-click'],
     props: {
         /** @model */
         modelValue: {

--- a/packages/oruga-next/src/components/select/Select.vue
+++ b/packages/oruga-next/src/components/select/Select.vue
@@ -9,7 +9,8 @@
             :multiple="multiple"
             :size="nativeSize"
             @blur="onBlur"
-            @focus="onFocus">
+            @focus="onFocus"
+            @invalid="onInvalid">
 
             <template v-if="placeholder">
                 <option
@@ -64,7 +65,7 @@ export default defineComponent({
     mixins: [BaseComponentMixin, FormElementMixin],
     configField: 'select',
     inheritAttrs: false,
-    emits: ['update:modelValue', 'focus', 'blur'],
+    emits: ['update:modelValue', 'focus', 'blur', 'invalid'],
     props: {
         /** @model */
         modelValue: {

--- a/packages/oruga-next/src/components/timepicker/Timepicker.vue
+++ b/packages/oruga-next/src/components/timepicker/Timepicker.vue
@@ -132,7 +132,8 @@
             :use-html5-validation="useHtml5Validation"
             @change="onChange($event.target.value)"
             @focus="handleOnFocus"
-            @blur="onBlur() && checkHtml5Validity()"/>
+            @blur="onBlur"
+            @invalid="onInvalid" />
     </div>
 </template>
 
@@ -194,6 +195,7 @@ export default defineComponent({
             }
         }
     },
+    emits: ['focus', 'blur', 'invalid'],
     computed: {
         inputBind() {
             return {

--- a/packages/oruga-next/src/utils/FormElementMixin.ts
+++ b/packages/oruga-next/src/utils/FormElementMixin.ts
@@ -129,6 +129,11 @@ export default defineComponent({
 			this.$emit("focus", event);
 		},
 
+		onInvalid(event: Event) {
+			this.checkHtml5Validity();
+			this.$emit("invalid", event);
+		},
+
 		getElement() {
 			let el = this.$refs[this.$elementRef];
 			while (el && el.$elementRef) {
@@ -169,7 +174,7 @@ export default defineComponent({
 			const el = this.getElement();
 			if (!el) return;
 
-			if (!el.checkValidity()) {
+			if (!el.validity.valid) {
 				this.setInvalid();
 				this.isValid = false;
 			} else {

--- a/packages/oruga-next/src/utils/FormElementMixin.ts
+++ b/packages/oruga-next/src/utils/FormElementMixin.ts
@@ -178,7 +178,7 @@ export default defineComponent({
 						// which should mean that the message will be visible onscreen.
 						// scrollIntoViewIfNeeded() is a non-standard method (but a very common extension).
 						// If we can't use it, we'll just fall back to focusing the field.
-						const canScrollToField = fieldElement?.scrollIntoViewIfNeeded != undefined;
+						const canScrollToField = fieldElement ? fieldElement.scrollIntoViewIfNeeded != undefined : false;
 						validatable.focus({ preventScroll: canScrollToField });
 						if (canScrollToField) {
 							fieldElement.scrollIntoViewIfNeeded();

--- a/packages/oruga-next/src/utils/FormElementMixin.ts
+++ b/packages/oruga-next/src/utils/FormElementMixin.ts
@@ -169,15 +169,20 @@ export default defineComponent({
 					}
 				}
 				if (isFirstInvalid) {
-					// We'll scroll to put the whole field in view, not just the element that triggered the event,
-					// which should mean that the message will be visible onscreen.
 					const fieldElement = this.parentField.$el;
-					// scrollIntoViewIfNeeded() is a non-standard method (but a very common extension).
-					// If we can't use it, we'll just fall back to focusing the field.
-					const canScrollToField = fieldElement?.scrollIntoViewIfNeeded != undefined;
-					validatable.focus({ preventScroll: canScrollToField });
-					if (canScrollToField) {
-						fieldElement.scrollIntoViewIfNeeded();
+					const invalidHandler = getValueByPath(getOptions(), 'reportInvalidInput');
+					if (invalidHandler instanceof Function) {
+						invalidHandler(validatable, fieldElement);
+					} else {
+						// We'll scroll to put the whole field in view, not just the element that triggered the event,
+						// which should mean that the message will be visible onscreen.
+						// scrollIntoViewIfNeeded() is a non-standard method (but a very common extension).
+						// If we can't use it, we'll just fall back to focusing the field.
+						const canScrollToField = fieldElement?.scrollIntoViewIfNeeded != undefined;
+						validatable.focus({ preventScroll: canScrollToField });
+						if (canScrollToField) {
+							fieldElement.scrollIntoViewIfNeeded();
+						}
 					}
 				}
 			}

--- a/packages/oruga-next/src/utils/FormElementMixin.ts
+++ b/packages/oruga-next/src/utils/FormElementMixin.ts
@@ -4,7 +4,7 @@ import { getValueByPath } from './helpers'
 
 // This should cover all types of HTML elements that have properties related to
 // HTML constraint validation, e.g. .form and .validity.
-const validatableFormElementTypes = [
+const validatableFormElementTypes = typeof window === 'undefined' ? [] : [
   HTMLButtonElement,
   HTMLFieldSetElement,
   HTMLInputElement,
@@ -13,6 +13,7 @@ const validatableFormElementTypes = [
   HTMLSelectElement,
   HTMLTextAreaElement,
 ];
+
 type ValidatableFormElement = InstanceType<typeof validatableFormElementTypes[number]>;
 
 function asValidatableFormElement(el: unknown): ValidatableFormElement | null {

--- a/packages/oruga-next/src/utils/FormElementMixin.ts
+++ b/packages/oruga-next/src/utils/FormElementMixin.ts
@@ -2,6 +2,27 @@ import { defineComponent } from 'vue'
 import { getOptions } from './config';
 import { getValueByPath } from './helpers'
 
+// This should cover all types of HTML elements that have properties related to
+// HTML constraint validation, e.g. .form and .validity.
+const validatableFormElementTypes = [
+  HTMLButtonElement,
+  HTMLFieldSetElement,
+  HTMLInputElement,
+  HTMLObjectElement,
+  HTMLOutputElement,
+  HTMLSelectElement,
+  HTMLTextAreaElement,
+];
+type ValidatableFormElement = InstanceType<typeof validatableFormElementTypes[number]>;
+
+function asValidatableFormElement(el: unknown): ValidatableFormElement | null {
+	if (validatableFormElementTypes.some(t => el instanceof t)) {
+		return el as ValidatableFormElement;
+	} else {
+		return null;
+	}
+}
+
 export default defineComponent({
 	inject: {
         $field: { from: "$field", default: false }
@@ -131,6 +152,35 @@ export default defineComponent({
 
 		onInvalid(event: Event) {
 			this.checkHtml5Validity();
+			const validatable = asValidatableFormElement(event.target);
+			if (validatable && this.parentField && this.useHtml5Validation) {
+				// We provide our own error message on the field, so we should suppress the browser's default tooltip.
+				// We still want to focus the form's first invalid input, though.
+				event.preventDefault();
+				let isFirstInvalid = false;
+				if (validatable.form != null) {
+					const formElements = validatable.form.elements;
+					for (let i = 0; i < formElements.length; ++i) {
+						const element = asValidatableFormElement(formElements.item(i));
+						if (element && element.willValidate && !element.validity.valid) {
+							isFirstInvalid = (validatable === element);
+							break;
+						}
+					}
+				}
+				if (isFirstInvalid) {
+					// We'll scroll to put the whole field in view, not just the element that triggered the event,
+					// which should mean that the message will be visible onscreen.
+					const fieldElement = this.parentField.$el;
+					// scrollIntoViewIfNeeded() is a non-standard method (but a very common extension).
+					// If we can't use it, we'll just fall back to focusing the field.
+					const canScrollToField = fieldElement?.scrollIntoViewIfNeeded != undefined;
+					validatable.focus({ preventScroll: canScrollToField });
+					if (canScrollToField) {
+						fieldElement.scrollIntoViewIfNeeded();
+					}
+				}
+			}
 			this.$emit("invalid", event);
 		},
 

--- a/packages/oruga/src/components/autocomplete/Autocomplete.vue
+++ b/packages/oruga/src/components/autocomplete/Autocomplete.vue
@@ -19,6 +19,7 @@
             @input="onInput"
             @focus="focused"
             @blur="onBlur"
+            @invalid="onInvalid"
             @keydown.native="keydown"
             @keydown.native.up.prevent="keyArrows('up')"
             @keydown.native.down.prevent="keyArrows('down')"

--- a/packages/oruga/src/components/datepicker/Datepicker.vue
+++ b/packages/oruga/src/components/datepicker/Datepicker.vue
@@ -236,7 +236,8 @@
             :use-html5-validation="false"
             @change.native="onChangeNativePicker"
             @focus="onFocus"
-            @blur="onBlur"/>
+            @blur="onBlur"
+            @invalid="onInvalid" />
     </div>
 </template>
 

--- a/packages/oruga/src/components/datetimepicker/Datetimepicker.vue
+++ b/packages/oruga/src/components/datetimepicker/Datetimepicker.vue
@@ -73,7 +73,8 @@
         :use-html5-validation="useHtml5Validation"
         @change.native="onChangeNativePicker"
         @focus="onFocus"
-        @blur="onBlur"/>
+        @blur="onBlur"
+        @invalid="onInvalid" />
 </template>
 
 <script>

--- a/packages/oruga/src/components/input/Input.vue
+++ b/packages/oruga/src/components/input/Input.vue
@@ -11,7 +11,8 @@
             :value="computedValue"
             @input="computedValue = $event.target.value"
             @blur="onBlur"
-            @focus="onFocus">
+            @focus="onFocus"
+            @invalid="onInvalid" />
 
         <textarea
             v-else
@@ -23,6 +24,7 @@
             @input="computedValue = $event.target.value"
             @blur="onBlur"
             @focus="onFocus"
+            @invalid="onInvalid"
             :style="computedStyles"
             />
 

--- a/packages/oruga/src/components/inputitems/Inputitems.vue
+++ b/packages/oruga/src/components/inputitems/Inputitems.vue
@@ -49,6 +49,7 @@
                 @typing="onTyping"
                 @focus="onFocus"
                 @blur="customOnBlur"
+                @invalid="onInvalid"
                 @keydown.native="keydown"
                 @compositionstart.native="isComposing = true"
                 @compositionend.native="isComposing = false"

--- a/packages/oruga/src/components/select/Select.vue
+++ b/packages/oruga/src/components/select/Select.vue
@@ -9,7 +9,8 @@
             :size="nativeSize"
             v-bind="$attrs"
             @blur="onBlur"
-            @focus="onFocus">
+            @focus="onFocus"
+            @invalid="onInvalid">
 
             <template v-if="placeholder">
                 <option

--- a/packages/oruga/src/components/timepicker/Timepicker.vue
+++ b/packages/oruga/src/components/timepicker/Timepicker.vue
@@ -132,7 +132,8 @@
             :use-html5-validation="useHtml5Validation"
             @change.native="onChange($event.target.value)"
             @focus="handleOnFocus"
-            @blur="onBlur() && checkHtml5Validity()"/>
+            @blur="onBlur() && checkHtml5Validity()"
+            @invalid="onInvalid" />
     </div>
 </template>
 

--- a/packages/oruga/src/utils/FormElementMixin.js
+++ b/packages/oruga/src/utils/FormElementMixin.js
@@ -3,14 +3,14 @@ import { getValueByPath } from './helpers'
 
 // This should cover all types of HTML elements that have properties related to
 // HTML constraint validation, e.g. .form and .validity.
-const validatableFormElementTypes = [
-  HTMLButtonElement,
-  HTMLFieldSetElement,
-  HTMLInputElement,
-  HTMLObjectElement,
-  HTMLOutputElement,
-  HTMLSelectElement,
-  HTMLTextAreaElement,
+const validatableFormElementTypes = typeof window === 'undefined' ? [] : [
+    HTMLButtonElement,
+    HTMLFieldSetElement,
+    HTMLInputElement,
+    HTMLObjectElement,
+    HTMLOutputElement,
+    HTMLSelectElement,
+    HTMLTextAreaElement,
 ];
 
 function asValidatableFormElement(el) {

--- a/packages/oruga/src/utils/FormElementMixin.js
+++ b/packages/oruga/src/utils/FormElementMixin.js
@@ -175,7 +175,7 @@ export default {
 						// which should mean that the message will be visible onscreen.
 						// scrollIntoViewIfNeeded() is a non-standard method (but a very common extension).
 						// If we can't use it, we'll just fall back to focusing the field.
-						const canScrollToField = fieldElement?.scrollIntoViewIfNeeded != undefined;
+						const canScrollToField = fieldElement ? fieldElement.scrollIntoViewIfNeeded != undefined : false;
 						validatable.focus({ preventScroll: canScrollToField });
 						if (canScrollToField) {
 							fieldElement.scrollIntoViewIfNeeded();

--- a/packages/oruga/src/utils/FormElementMixin.js
+++ b/packages/oruga/src/utils/FormElementMixin.js
@@ -127,6 +127,11 @@ export default {
 			this.$emit("focus", event);
 		},
 
+		onInvalid(event) {
+			this.checkHtml5Validity();
+			this.$emit("invalid", event);
+		},
+
 		getElement() {
 			let el = this.$refs[this.$elementRef];
 			while (el && el.$elementRef) {
@@ -167,7 +172,7 @@ export default {
 			const el = this.getElement();
 			if (el === undefined) return;
 
-			if (!el.checkValidity()) {
+			if (!el.validity.valid) {
 				this.setInvalid();
 				this.isValid = false;
 			} else {

--- a/packages/oruga/src/utils/FormElementMixin.js
+++ b/packages/oruga/src/utils/FormElementMixin.js
@@ -166,15 +166,20 @@ export default {
 					}
 				}
 				if (isFirstInvalid) {
-					// We'll scroll to put the whole field in view, not just the element that triggered the event,
-					// which should mean that the message will be visible onscreen.
 					const fieldElement = this.parentField.$el;
-					// scrollIntoViewIfNeeded() is a non-standard method (but a very common extension).
-					// If we can't use it, we'll just fall back to focusing the field.
-					const canScrollToField = fieldElement?.scrollIntoViewIfNeeded != undefined;
-					validatable.focus({ preventScroll: canScrollToField });
-					if (canScrollToField) {
-						fieldElement.scrollIntoViewIfNeeded();
+					const invalidHandler = getValueByPath(getOptions(), 'reportInvalidInput');
+					if (invalidHandler instanceof Function) {
+						invalidHandler(validatable, fieldElement);
+					} else {
+						// We'll scroll to put the whole field in view, not just the element that triggered the event,
+						// which should mean that the message will be visible onscreen.
+						// scrollIntoViewIfNeeded() is a non-standard method (but a very common extension).
+						// If we can't use it, we'll just fall back to focusing the field.
+						const canScrollToField = fieldElement?.scrollIntoViewIfNeeded != undefined;
+						validatable.focus({ preventScroll: canScrollToField });
+						if (canScrollToField) {
+							fieldElement.scrollIntoViewIfNeeded();
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Rather than emitting `invalid` events on blur, we should be listening for them.

Fixes #407
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- `FormElementMixin.checkHtml5Validity` checks the `validity` property rather than calling `checkValidity`, so it doesn't emit `invalid` events on blur.
- Controls that use `FormElementMixin` respond to `invalid` events, which the browser fires when their containing form is submitted.

## Open Questions

- [ ] Should we suppress the browser's native HTML5 validation pop-ups?
  When the form is submitted, most browsers will focus the first invalid field and display a pop-up with a validation message. This is standard behavior for plain HTML inputs, but for Oruga controls inside a field, the pop-up is redundant because we provide our own user-visible error message. Should we suppress the browser's native pop-up by default?
