### PR TITLE
Fix modal calling onClose twice

### DIFF
--- a/packages/oruga-next/src/components/modal/Modal.vue
+++ b/packages/oruga-next/src/components/modal/Modal.vue
@@ -301,7 +301,6 @@ export default defineComponent({
             if (this.destroyOnHide) {
                 this.destroyed = true
             }
-            this.$emit('close')
             this.$emit('update:active', false)
             this.onClose.apply(null, arguments)
 


### PR DESCRIPTION
Fixes #333

In `oruga-next`, the `close` event was being sent twice. Both `this.$emit('close')` and `this.onClose.apply(null, arguments)` send the `close` event. We can delete either of those statements to get a single `close` event to fire. I chose to delete `this.$emit('close')` because it wasn't sending arguments.

This double `close` event behavior does not seem to happen in `oruga`, so I did not make any changes there.