### PR TITLE
Fixes message slot in OField component when horizontal

### DIFF
--- a/packages/docs-next/.vitepress/theme/examples/field/inspector.vue
+++ b/packages/docs-next/.vitepress/theme/examples/field/inspector.vue
@@ -74,6 +74,10 @@ export default {
           }
         },
         {
+          class: "fieldInputWrapperClass",
+          description: "Class for wrapper that contains input and message",
+        },
+        {
           class: "bodyClass",
           description: "Class for field body"
         },

--- a/packages/docs/components/Field.md
+++ b/packages/docs/components/Field.md
@@ -332,6 +332,10 @@ export default {
                     }
                 },
                 {
+                    class: "fieldInputWrapperClass",
+                    description: "Class for wrapper that contains input and message",
+                },
+                {
                     class: "bodyClass",
                     description: "Class for field body"
                 },

--- a/packages/oruga-next/src/components/field/Field.spec.js
+++ b/packages/oruga-next/src/components/field/Field.spec.js
@@ -58,6 +58,52 @@ describe('OField', () => {
         })
     })
 
+    describe('Passing horizontal prop', () => {
+        const generateMountOptions = (props) => {
+            return {
+                propsData: props,
+                localVue,
+                slots: {
+                    default: [OInput, '<button class="button">Button</button>']
+                }
+            }
+        }
+
+        describe('when horizontal props is true', () => {
+            let wrapper
+
+            beforeEach(() => {
+                const mountOptions = generateMountOptions({ horizontal: true })
+                wrapper = shallowMount(OField, mountOptions)
+            })
+
+            it('sets horizontal classes correctly when horizontal is true', () => {
+                expect(wrapper.find('.o-field__horizontal-label').exists()).toBe(true)
+            })
+
+            it('renders OFieldBody component', () => {
+                expect(wrapper.find(OFieldBody).exists()).toBe(true)
+            })
+        })
+
+        describe('when horizontal props is false', () => {
+            let wrapper
+
+            beforeEach(() => {
+                const mountOptions = generateMountOptions({ horizontal: false })
+                wrapper = shallowMount(OField, mountOptions)
+            })
+
+            it('does not set horizontal classes when horizontal is false', () => {
+                expect(wrapper.find('.o-field__horizontal-label').exists()).toBe(false)
+            })
+
+            it('does not render OFieldBody component', () => {
+                expect(wrapper.find(OFieldBody).exists()).toBe(false)
+            })
+        })
+    })
+
     describe('managing groups', () => {
         const mountOptions = {
             propsData: {

--- a/packages/oruga-next/src/components/field/Field.vue
+++ b/packages/oruga-next/src/components/field/Field.vue
@@ -1,8 +1,6 @@
 <template>
     <div :class="rootClasses">
-        <div
-            v-if="horizontal"
-            :class="labelHorizontalClasses">
+        <div :class="horizontal ? labelHorizontalClasses : ''">
             <label
                 v-if="hasLabel"
                 :for="labelFor"
@@ -11,33 +9,23 @@
                 <template v-else>{{ label }}</template>
             </label>
         </div>
-        <template v-else>
-            <label
-                v-if="hasLabel"
-                :for="labelFor"
-                :class="labelClasses">
-                <slot v-if="hasLabelSlot" name="label"/>
-                <template v-else>{{ label }}</template>
-            </label>
-        </template>
-        <o-field-body v-if="horizontal">
-            <slot/>
-        </o-field-body>
-        <div v-else-if="hasInnerField" :class="bodyClasses">
-            <div :class="innerFieldClasses">
+        <div :class="fieldInputWrapperClasses">
+            <o-field-body v-if="horizontal">
                 <slot/>
+            </o-field-body>
+            <div v-else-if="hasInnerField" :class="bodyClasses">
+                <div :class="innerFieldClasses">
+                    <slot/>
+                </div>
             </div>
+            <template v-else>
+                <slot />
+            </template>
+            <p v-if="hasMessage" :class="messageClasses">
+                <slot v-if="hasMessageSlot" name="message"/>
+                <template v-else>{{ newMessage }}</template>
+            </p>
         </div>
-        <template v-else>
-            <slot/>
-        </template>
-        <p
-            v-if="hasMessage && !horizontal"
-            :class="messageClasses"
-        >
-            <slot v-if="hasMessageSlot" name="message"/>
-            <template v-else>{{ newMessage }}</template>
-        </p>
     </div>
 </template>
 
@@ -106,7 +94,7 @@ export default defineComponent({
             type: Boolean,
             default: true
         },
-         /**
+        /**
          * Vertical size of input, optional
          * @values small, medium, large
          */
@@ -118,6 +106,7 @@ export default defineComponent({
         labelClass: [String, Function, Array],
         labelSizeClass: [String, Function, Array],
         labelHorizontalClass: [String, Function, Array],
+        fieldInputWrapperClass: [String, Function, Array],
         bodyClass: [String, Function, Array],
         bodyHorizontalClass: [String, Function, Array],
         addonsClass: [String, Function, Array],
@@ -162,6 +151,11 @@ export default defineComponent({
         labelHorizontalClasses() {
             return [
                 this.computedClass('labelHorizontalClass', 'o-field__horizontal-label')
+            ]
+        },
+        fieldInputWrapperClasses() {
+            return [
+                this.computedClass('fieldInputWrapperClass', 'o-field__input-wrapper')
             ]
         },
         bodyClasses() {

--- a/packages/oruga/src/components/field/Field.spec.js
+++ b/packages/oruga/src/components/field/Field.spec.js
@@ -58,6 +58,52 @@ describe('OField', () => {
         })
     })
 
+    describe('Passing horizontal prop', () => {
+        const generateMountOptions = (props) => {
+            return {
+                propsData: props,
+                localVue,
+                slots: {
+                    default: [OInput, '<button class="button">Button</button>']
+                }
+            }
+        }
+
+        describe('when horizontal props is true', () => {
+            let wrapper
+
+            beforeEach(() => {
+                const mountOptions = generateMountOptions({ horizontal: true })
+                wrapper = shallowMount(OField, mountOptions)
+            })
+
+            it('sets horizontal classes correctly when horizontal is true', () => {
+                expect(wrapper.find('.o-field__horizontal-label').exists()).toBe(true)
+            })
+
+            it('renders OFieldBody component', () => {
+                expect(wrapper.find(OFieldBody).exists()).toBe(true)
+            })
+        })
+
+        describe('when horizontal props is false', () => {
+            let wrapper
+
+            beforeEach(() => {
+                const mountOptions = generateMountOptions({ horizontal: false })
+                wrapper = shallowMount(OField, mountOptions)
+            })
+
+            it('does not set horizontal classes when horizontal is false', () => {
+                expect(wrapper.find('.o-field__horizontal-label').exists()).toBe(false)
+            })
+
+            it('does not render OFieldBody component', () => {
+                expect(wrapper.find(OFieldBody).exists()).toBe(false)
+            })
+        })
+    })
+
     describe('managing groups', () => {
         const mountOptions = {
             propsData: {

--- a/packages/oruga/src/components/field/Field.vue
+++ b/packages/oruga/src/components/field/Field.vue
@@ -1,8 +1,6 @@
 <template>
     <div :class="rootClasses">
-        <div
-            v-if="horizontal"
-            :class="labelHorizontalClasses">
+        <div :class="horizontal ? labelHorizontalClasses : ''">
             <label
                 v-if="hasLabel"
                 :for="labelFor"
@@ -11,33 +9,23 @@
                 <template v-else>{{ label }}</template>
             </label>
         </div>
-        <template v-else>
-            <label
-                v-if="hasLabel"
-                :for="labelFor"
-                :class="labelClasses">
-                <slot v-if="hasLabelSlot" name="label"/>
-                <template v-else>{{ label }}</template>
-            </label>
-        </template>
-        <o-field-body v-if="horizontal">
-            <slot/>
-        </o-field-body>
-        <div v-else-if="hasInnerField" :class="bodyClasses">
-            <div :class="innerFieldClasses">
+        <div :class="fieldInputWrapperClasses">
+            <o-field-body v-if="horizontal">
                 <slot/>
+            </o-field-body>
+            <div v-else-if="hasInnerField" :class="bodyClasses">
+                <div :class="innerFieldClasses">
+                    <slot/>
+                </div>
             </div>
+            <template v-else>
+                <slot />
+            </template>
+            <p v-if="hasMessage" :class="messageClasses">
+                <slot v-if="hasMessageSlot" name="message"/>
+                <template v-else>{{ newMessage }}</template>
+            </p>
         </div>
-        <template v-else>
-            <slot />
-        </template>
-        <p
-            v-if="hasMessage && !horizontal"
-            :class="messageClasses"
-        >
-            <slot v-if="hasMessageSlot" name="message"/>
-            <template v-else>{{ newMessage }}</template>
-        </p>
     </div>
 </template>
 
@@ -117,6 +105,7 @@ export default {
         labelClass: [String, Function, Array],
         labelSizeClass: [String, Function, Array],
         labelHorizontalClass: [String, Function, Array],
+        fieldInputWrapperClass: [String, Function, Array],
         bodyClass: [String, Function, Array],
         bodyHorizontalClass: [String, Function, Array],
         addonsClass: [String, Function, Array],
@@ -161,6 +150,11 @@ export default {
         labelHorizontalClasses() {
             return [
                 this.computedClass('labelHorizontalClass', 'o-field__horizontal-label')
+            ]
+        },
+        fieldInputWrapperClasses() {
+            return [
+                this.computedClass('fieldInputWrapperClass', 'o-field__input-wrapper')
             ]
         },
         bodyClasses() {

--- a/packages/oruga/src/components/field/Inspector.vue
+++ b/packages/oruga/src/components/field/Inspector.vue
@@ -75,6 +75,10 @@ export default {
                     }
                 },
                 {
+                    class: "fieldInputWrapperClass",
+                    description: "Class for wrapper that contains input and message",
+                },
+                {
                     class: "bodyClass",
                     description: "Class for field body"
                 },

--- a/packages/oruga/src/components/field/__snapshots__/Field.spec.js.snap
+++ b/packages/oruga/src/components/field/__snapshots__/Field.spec.js.snap
@@ -2,7 +2,11 @@
 
 exports[`OField render correctly 1`] = `
 <div class="o-field">
-    <!---->
-    <!---->
+    <div class="">
+        <!---->
+    </div>
+    <div class="o-field__input-wrapper">
+        <!---->
+    </div>
 </div>
 `;

--- a/packages/oruga/src/scss/components/_field.scss
+++ b/packages/oruga/src/scss/components/_field.scss
@@ -98,6 +98,9 @@ $field-horizontal-label-margin: 0 1.5rem 0 0 !default;
     }
     &__input-wrapper {
         display: flex;
+        flex-basis: 0;
+        flex-grow: 5;
+        flex-shrink: 1;
         flex-direction: column;
         width: 100%;
     }

--- a/packages/oruga/src/scss/components/_field.scss
+++ b/packages/oruga/src/scss/components/_field.scss
@@ -81,7 +81,10 @@ $field-horizontal-label-margin: 0 1.5rem 0 0 !default;
         flex-basis: 0;
         flex-grow: 5;
         flex-shrink: 1;
-        @include side-flex-gap($field-margin-right);
+
+        @media (min-width: 1024px) {
+            @include side-flex-gap($field-margin-right);
+        }
     }
     &--horizontal {
         display: flex;
@@ -92,6 +95,11 @@ $field-horizontal-label-margin: 0 1.5rem 0 0 !default;
         flex-shrink: 0;
         margin: $field-horizontal-label-margin;
         text-align: right;
+    }
+    &__input-wrapper {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
     }
     &--mobile {
         .o-field__horizontal-body {


### PR DESCRIPTION
Fixes #427 

## Proposed Changes

- Keep `message` slot when component has `horizontal` props.
- Refactor `Field` component to avoid code duplication.
- Fix input spacing on mobile.

Before:
![image](https://user-images.githubusercontent.com/17005849/197893506-670e969a-320f-4688-99e7-3edba5e35e51.png)
![image](https://user-images.githubusercontent.com/17005849/197892239-1a956990-e562-451d-8306-4e0504392901.png)


After:
![image](https://user-images.githubusercontent.com/17005849/197893303-97b6a60a-92cf-46b9-a73b-d02d7bf0cbba.png)
![image](https://user-images.githubusercontent.com/17005849/197891980-34c29a47-8599-44e2-b2ae-ebcf39c4ca24.png)

