### PR TITLE
fix(select): pass autocomplete prop through

### DIFF
--- a/packages/oruga-next/src/components/select/Select.vue
+++ b/packages/oruga-next/src/components/select/Select.vue
@@ -5,6 +5,7 @@
             v-model="computedValue"
             :class="selectClasses"
             ref="select"
+            :autocomplete="autocomplete"
             :multiple="multiple"
             :size="nativeSize"
             @blur="onBlur"

--- a/packages/oruga/src/components/select/Select.vue
+++ b/packages/oruga/src/components/select/Select.vue
@@ -4,6 +4,7 @@
             :class="selectClasses"
             v-model="computedValue"
             ref="select"
+            :autocomplete="autocomplete"
             :multiple="multiple"
             :size="nativeSize"
             v-bind="$attrs"


### PR DESCRIPTION
## Proposed Changes

Passes `autocomplete` prop through to `<OSelect>` like we would for other form elements.