### PR TITLE
fix cdn link typo

### DIFF
--- a/packages/docs-next/documentation/index.md
+++ b/packages/docs-next/documentation/index.md
@@ -50,8 +50,8 @@ npm install @oruga-ui/oruga-next --save
 <o-tab-item override label="Cdn" itemHeaderTypeClass="installation-tabs-nav-button-" itemHeaderActiveClass="installation-tabs-nav-button-active-">
 
 ```html
-<link rel="stylesheet" href="//unpkg.com/oruga-next/dist/oruga.css" />
-<script src="//unpkg.com/oruga-next/dist/oruga.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/@oruga-ui/oruga-next/dist/oruga.min.css" />
+<script src="https://unpkg.com/@oruga-ui/oruga-next/dist/oruga.min.js"></script>
 ```
 
 </o-tab-item>

--- a/packages/docs/documentation/README.md
+++ b/packages/docs/documentation/README.md
@@ -52,8 +52,8 @@ npm install @oruga-ui/oruga --save
 <o-tab-item override label="Cdn" itemHeaderTypeClass="installation-tabs-nav-button-" itemHeaderActiveClass="installation-tabs-nav-button-active-">
 
 ```html
-<link rel="stylesheet" href="//unpkg.com/oruga/dist/oruga.min.css" />
-<script src="//unpkg.com/oruga/dist/oruga.min.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/@oruga-ui/oruga/dist/oruga.min.css" />
+<script src="https://unpkg.com/@oruga-ui/oruga/dist/oruga.min.js"></script>
 ```
 
 </o-tab-item>


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #468 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

-  `oruga/dist/` and `oruga-next/dist/` are the wrong paths, and the correct paths should be `@oruga-ui/oruga/dist/` and `@oruga-ui/oruga-next/dist/`
