### PR TITLE
fix: changed background for background-color on .o-chk_check

### DIFF
--- a/packages/oruga/src/scss/components/_checkbox.scss
+++ b/packages/oruga/src/scss/components/_checkbox.scss
@@ -1,4 +1,3 @@
-
 /* @docs */
 $checkbox-active-background-color: $primary !default;
 $checkbox-background-color: $primary !default;
@@ -9,7 +8,7 @@ $checkbox-checked-box-shadow-length: 0 0 0.5em !default;
 $checkbox-checked-box-shadow-opacity: 0.8 !default;
 $checkbox-checkmark-color: $primary-invert !default;
 $checkbox-disabled-opacity: $base-disabled-opacity !default;
-$checkbox-label-padding: 0 0 0 .5em !default;
+$checkbox-label-padding: 0 0 0 0.5em !default;
 $checkbox-margin-sibiling: 0.5em !default;
 $checkbox-size: 1rem !default;
 $checkbox-line-height: 1.5 !default;
@@ -19,14 +18,14 @@ $checkbox-line-height: 1.5 !default;
     $start: '<svg width="100%" height="100%" viewBox="0 0 234 225" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">';
     $content: '<g transform="matrix(4.16667,0,0,4.16667,0,0)"><g transform="matrix(3.13817,0,0,3.13817,-69.2796,-49.5156)"><path style="fill:#{$color}" d="M22.504,26.219L28.637,32.386L39.494,18.284L37.348,16.379L28,27.725L24.46,24.196L22.504,26.219Z"></path></g></g>';
     $end: '</svg>';
-    @return svg-encode("#{$start}#{$content}#{$end}");
+    @return svg-encode('#{$start}#{$content}#{$end}');
 }
 
 @function svg_indeterminate($color) {
     $start: '<svg width="100%" height="100%" viewBox="0 0 417 417" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">';
     $content: '<g transform="matrix(4.16667,0,0,4.16667,0,0)"><g transform="matrix(6.96176,0,0,20.5682,-118.661,-806.753)"><path style="fill:#{$color}" d="M31.265,41.654C31.265,41.324 30.474,41.057 29.5,41.057L18.953,41.057C17.979,41.057 17.188,41.324 17.188,41.654C17.188,41.984 17.979,42.252 18.953,42.252L29.5,42.252C30.474,42.252 31.265,41.984 31.265,41.654Z"/></g></g>';
     $end: '</svg>';
-    @return svg-encode("#{$start}#{$content}#{$end}");
+    @return svg-encode('#{$start}#{$content}#{$end}');
 }
 
 .o-chk {
@@ -41,7 +40,7 @@ $checkbox-line-height: 1.5 !default;
     &__check {
         @include avariable('width', 'checkbox-size', $checkbox-size);
         @include avariable('height', 'checkbox-size', $checkbox-size);
-        outline:none;
+        outline: none;
         margin: 0;
         vertical-align: top;
         background-position: center;
@@ -54,7 +53,7 @@ $checkbox-line-height: 1.5 !default;
         flex-shrink: 0;
         cursor: pointer;
         background-repeat: no-repeat;
-        @include avariable('background', 'checkbox-background-color', $checkbox-background-color);
+        @include avariable('background-color', 'checkbox-background-color', $checkbox-background-color);
         @include avariable('border-radius', 'checkbox-border-radius', $checkbox-border-radius);
         @include avariable('border-width', 'checkbox-border-width', $checkbox-border-width);
         @include avariable('border-color', 'checkbox-border-color', $checkbox-border-color);
@@ -64,12 +63,20 @@ $checkbox-line-height: 1.5 !default;
         @include avariable('transition-timing-function', 'transition-timing', $easing);
 
         &--checked {
-            @include avariable('background-color', 'checkbox-active-background-color', $checkbox-active-background-color);
+            @include avariable(
+                'background-color',
+                'checkbox-active-background-color',
+                $checkbox-active-background-color
+            );
             @include avariable('border-color', 'checkbox-active-background-color', $checkbox-active-background-color);
             background-image: url(svg_checkmark(variable('checkbox-checkmark-color', $checkbox-checkmark-color)));
         }
         &--indeterminate {
-            @include avariable('background-color', 'checkbox-active-background-color', $checkbox-active-background-color);
+            @include avariable(
+                'background-color',
+                'checkbox-active-background-color',
+                $checkbox-active-background-color
+            );
             @include avariable('border-color', 'checkbox-active-background-color', $checkbox-active-background-color);
             background-image: url(svg_indeterminate(variable('checkbox-checkmark-color', $checkbox-checkmark-color)));
         }


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- change CSS rule on `o-chk__check`, from:

 `@include avariable('background', 'checkbox-background-color', $checkbox-background-color);` 
to 

`@include avariable('background-color', 'checkbox-background-color', $checkbox-background-color);`

## Context

Right now we are using the `background` shorthand  to set a background color on ourga checkbox:

![image](https://user-images.githubusercontent.com/2030605/209939449-8434cc4d-22a5-49f6-a015-4d2cacd5bfb0.png)

This will override any other settings made in background rule (like background-position, backgrouns-size, etc) and previously set on the same class

This property should be `background-color` instead:

![image](https://user-images.githubusercontent.com/2030605/209940337-f8ed9734-3405-4fba-9e31-3bf17c9f301e.png)



