### PR TITLE
Fix wrong import for Vue3 example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ npm install @oruga-ui/oruga-next
  - To use tree shaking, either register component manually:
 
     ```js
-    import Vue from 'vue'
+    import { createApp } from 'vue'
     import { OField, OInput } from '@oruga-ui/oruga'
     import '@oruga-ui/oruga/dist/oruga.css'
     


### PR DESCRIPTION
The Setup -> Vue 3 code example in README.md imports ```import Vue from 'vue``` instead of createApp. This is most probably a copy/paste mistake.