### PR TITLE
Update Table.vue to fix footer rendering

### DIFF
--- a/packages/oruga-next/src/components/table/Table.vue
+++ b/packages/oruga-next/src/components/table/Table.vue
@@ -266,7 +266,7 @@
 
                 <tfoot v-if="$slots.footer">
                     <tr :class="footerClasses">
-                        <slot name="footer" v-if="hasCustomFooterSlot()"/>
+                        <slot name="footer" v-if="hasCustomFooterSlot"/>
                         <th :colspan="columnCount" v-else>
                             <slot name="footer"/>
                         </th>
@@ -772,6 +772,20 @@ export default defineComponent({
             const validVisibleData = this.visibleData.filter(
                 (row) => this.isRowCheckable(row))
             return validVisibleData.length === 0
+        },
+        
+        /**
+        * Check if footer slot has custom content.
+        */
+        hasCustomFooterSlot() {
+            if (this.$slots.footer) {
+                const footer = this.$slots.footer()
+                if (footer.length > 1) return true
+
+                const tag = footer[0].tag
+                if (tag !== 'th' && tag !== 'td') return false
+            }
+            return true
         },
 
         /**
@@ -1299,20 +1313,6 @@ export default defineComponent({
                     }
                 }
             }
-        },
-
-        /**
-        * Check if footer slot has custom content.
-        */
-        hasCustomFooterSlot() {
-            if (this.$slots.footer) {
-                const footer = this.$slots.footer()
-                if (footer.length > 1) return true
-
-                const tag = footer[0].tag
-                if (tag !== 'th' && tag !== 'td') return false
-            }
-            return true
         },
 
         /**

--- a/packages/oruga-next/src/components/table/Table.vue
+++ b/packages/oruga-next/src/components/table/Table.vue
@@ -266,9 +266,9 @@
 
                 <tfoot v-if="$slots.footer">
                     <tr :class="footerClasses">
-                        <slot name="footer" v-if="hasCustomFooterSlot"/>
+                        <slot name="footer" v-if="hasCustomFooterSlot" :columnCount="columnCount"/>
                         <th :colspan="columnCount" v-else>
-                            <slot name="footer"/>
+                            <slot name="footer" :columnCount="columnCount"/>
                         </th>
                     </tr>
                 </tfoot>


### PR DESCRIPTION
## Issue

- hasCustomFooterSlot as a function may be called when $slots.footer is not yet available and returns false. 


## Proposed Changes

- hasCustomFooterSlot should be a computed property, because it needs to recompute if $slots.footer changes


ps: actually, I don't get why Oruga tries to asses if it's a custom footer since there's no default footer. Just have the slot there and let users do whatever they want. Maybe bind columnCount to the slot and call it a day.
