### PR TITLE
fix: button-rounded-border-radius variable

### DIFF
--- a/packages/oruga/src/scss/components/_button.scss
+++ b/packages/oruga/src/scss/components/_button.scss
@@ -65,7 +65,7 @@ $button-disabled-opacity: $base-disabled-opacity !default;
         width: 100%;
     }
     &--rounded {
-        @include avariable('border-radius', 'button-border-radius', $button-rounded-border-radius);
+        @include avariable('border-radius', 'button-rounded-border-radius', $button-rounded-border-radius);
     }
     &--disabled {
         @include avariable('opacity', 'button-disabled-opacity', $button-disabled-opacity);


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

- [Fixes #505](https://github.com/oruga-ui/oruga/issues/505)

## Proposed Changes

- Change the variable `button-border-radius` to `button-rounded-border-radius` for rounded button.
