### PR TITLE
feat: allow to set background color on outlined button

### DIFF
--- a/packages/docs-next/components/Button.md
+++ b/packages/docs-next/components/Button.md
@@ -54,20 +54,21 @@ title: Button
 
 📄 [Full scss file](https://github.com/oruga-ui/oruga/blob/master/packages/oruga/src/scss/components/_button.scss)
 
-| CSS Variable                         | SASS Variable                  | Default                             |
-| ------------------------------------ | ------------------------------ | ----------------------------------- |
-| --oruga-button-background-color      | \$button-background-color      | \$primary                           |
-| --oruga-button-color                 | \$button-color                 | \$primary-invert                    |
-| --oruga-button-border-radius         | \$button-border-radius         | \$base-border-radius                |
-| --oruga-button-border                | \$button-border                | 1px solid \$button-background-color |
-| --oruga-button-box-shadow            | \$button-box-shadow            | none                                |
-| --oruga-button-font-weight           | \$button-font-weight           | 400                                 |
-| --oruga-button-line-height           | \$button-line-height           | \$base-line-height                  |
-| --oruga-button-margin-icon-to-text   | \$button-margin-icon-to-text   | .1875em                             |
-| --oruga-button-margin                | \$button-margin                | 0                                   |
-| --oruga-button-height                | \$button-height                | \$control-height                    |
-| --oruga-button-padding               | \$button-padding               | \$control-padding-vertical .75em    |
-| --oruga-button-rounded-border-radius | \$button-rounded-border-radius | \$base-rounded-border-radius        |
-| --oruga-button-disabled-opacity      | \$button-disabled-opacity      | \$base-disabled-opacity             |
+| CSS Variable                             | SASS Variable                      | Default                             |
+| ---------------------------------------- | ---------------------------------- | ----------------------------------- |
+| --oruga-button-background-color          | \$button-background-color          | \$primary                           |
+| --oruga-button-color                     | \$button-color                     | \$primary-invert                    |
+| --oruga-button-border-radius             | \$button-border-radius             | \$base-border-radius                |
+| --oruga-button-border                    | \$button-border                    | 1px solid \$button-background-color |
+| --oruga-button-box-shadow                | \$button-box-shadow                | none                                |
+| --oruga-button-font-weight               | \$button-font-weight               | 400                                 |
+| --oruga-button-line-height               | \$button-line-height               | \$base-line-height                  |
+| --oruga-button-margin-icon-to-text       | \$button-margin-icon-to-text       | .1875em                             |
+| --oruga-button-margin                    | \$button-margin                    | 0                                   |
+| --oruga-button-height                    | \$button-height                    | \$control-height                    |
+| --oruga-button-padding                   | \$button-padding                   | \$control-padding-vertical .75em    |
+| --oruga-button-rounded-border-radius     | \$button-rounded-border-radius     | \$base-rounded-border-radius        |
+| --oruga-button-disabled-opacity          | \$button-disabled-opacity          | \$base-disabled-opacity             |
+| --oruga-button-outlined-background-color | \$button-outlined-background-color | transparent                         |
 
 </div>

--- a/packages/docs/components/Button.md
+++ b/packages/docs/components/Button.md
@@ -323,18 +323,19 @@ export default {
 
 ## Style
 
-| CSS Variable                         | SASS Variable                  | Default                             |
-| ------------------------------------ | ------------------------------ | ----------------------------------- |
-| --oruga-button-background-color      | \$button-background-color      | \$primary                           |
-| --oruga-button-color                 | \$button-color                 | \$primary-invert                    |
-| --oruga-button-border-radius         | \$button-border-radius         | \$base-border-radius                |
-| --oruga-button-border                | \$button-border                | 1px solid \$button-background-color |
-| --oruga-button-box-shadow            | \$button-box-shadow            | none                                |
-| --oruga-button-font-weight           | \$button-font-weight           | 400                                 |
-| --oruga-button-line-height           | \$button-line-height           | \$base-line-height                  |
-| --oruga-button-margin-icon-to-text   | \$button-margin-icon-to-text   | .1875em                             |
-| --oruga-button-margin                | \$button-margin                | 0                                   |
-| --oruga-button-height                | \$button-height                | \$control-height                    |
-| --oruga-button-padding               | \$button-padding               | \$control-padding-vertical .75em    |
-| --oruga-button-rounded-border-radius | \$button-rounded-border-radius | \$base-rounded-border-radius        |
-| --oruga-button-disabled-opacity      | \$button-disabled-opacity      | \$base-disabled-opacity             |
+| CSS Variable                             | SASS Variable                      | Default                             |
+| ---------------------------------------- | ---------------------------------- | ----------------------------------- |
+| --oruga-button-background-color          | \$button-background-color          | \$primary                           |
+| --oruga-button-color                     | \$button-color                     | \$primary-invert                    |
+| --oruga-button-border-radius             | \$button-border-radius             | \$base-border-radius                |
+| --oruga-button-border                    | \$button-border                    | 1px solid \$button-background-color |
+| --oruga-button-box-shadow                | \$button-box-shadow                | none                                |
+| --oruga-button-font-weight               | \$button-font-weight               | 400                                 |
+| --oruga-button-line-height               | \$button-line-height               | \$base-line-height                  |
+| --oruga-button-margin-icon-to-text       | \$button-margin-icon-to-text       | .1875em                             |
+| --oruga-button-margin                    | \$button-margin                    | 0                                   |
+| --oruga-button-height                    | \$button-height                    | \$control-height                    |
+| --oruga-button-padding                   | \$button-padding                   | \$control-padding-vertical .75em    |
+| --oruga-button-rounded-border-radius     | \$button-rounded-border-radius     | \$base-rounded-border-radius        |
+| --oruga-button-disabled-opacity          | \$button-disabled-opacity          | \$base-disabled-opacity             |
+| --oruga-button-outlined-background-color | \$button-outlined-background-color | transparent                         |

--- a/packages/oruga/src/scss/components/_button.scss
+++ b/packages/oruga/src/scss/components/_button.scss
@@ -13,6 +13,7 @@ $button-height: $control-height !default;
 $button-padding: $control-padding-vertical .75em !default;
 $button-rounded-border-radius: $base-rounded-border-radius !default;
 $button-disabled-opacity: $base-disabled-opacity !default;
+$button-outlined-background-color: transparent !default;
 /* @docs */
 
 
@@ -92,7 +93,7 @@ $button-disabled-opacity: $base-disabled-opacity !default;
         }
     }
     &--outlined {
-        background-color: transparent;
+        @include avariable('background-color', 'button-outlined-background-color', $button-outlined-background-color);
         @include avariable('border-color', 'button-background-color', $button-background-color);
         @include avariable('color', 'button-background-color', $button-background-color);
         &:hover {
@@ -104,7 +105,7 @@ $button-disabled-opacity: $base-disabled-opacity !default;
             $color: nth($pair, 1);
             $color-invert: nth($pair, 2);
             &-#{$name} {
-                background-color: transparent;
+                @include avariable('background-color', 'button-outlined-background-color', $button-outlined-background-color);
                 @include avariable('border-color', ('variant-' + #{$name}), $color);
                 @include avariable('color', ('variant-' + #{$name}), $color);
                 &:hover {

--- a/packages/oruga/src/scss/oruga.scss
+++ b/packages/oruga/src/scss/oruga.scss
@@ -18,7 +18,8 @@ $whitelist: add-to-whitelist(
 $whitelist: add-to-whitelist(
     'button-background-color',
     'button-color',
-    'button-disabled-opacity'
+    'button-disabled-opacity',
+    'button-outlined-background-color'
 );
 
 // carousel


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

- Customise background color of outlined buttons.

## Proposed Changes

- Add a new variable `button-outlined-background-color` (or another that you like more).
- Allow to set the background color of outlined buttons, like `#ffffff` instead of transparent.
