### PR TITLE
Adds slot preheader in Table.vue

### DIFF
--- a/packages/docs-next/components/Table.md
+++ b/packages/docs-next/components/Table.md
@@ -132,6 +132,7 @@ title: Table
 | footer      |             |          |
 | loading     |             |          |
 | bottom-left |             |          |
+| preheader   | A slot inside `<thead>` above the normal header row. | |
 
 ---
 

--- a/packages/docs/components/Table.md
+++ b/packages/docs/components/Table.md
@@ -2105,6 +2105,7 @@ export default {
 | footer      |             |          |
 | loading     |             |          |
 | bottom-left |             |          |
+| preheader   | A slot inside `<thead>` above the normal header row. | |
 
 ---
 

--- a/packages/oruga-next/src/components/table/Table.vue
+++ b/packages/oruga-next/src/components/table/Table.vue
@@ -53,6 +53,7 @@
                     <slot name="caption" />
                 </caption>
                 <thead v-if="newColumns.length && showHeader">
+                    <slot name="preheader" />
                     <tr>
                         <th v-if="showDetailRowIcon" :class="thDetailedClasses"/>
                         <th :class="thCheckboxClasses" v-if="checkable && checkboxPosition === 'left'">

--- a/packages/oruga/src/components/table/Table.vue
+++ b/packages/oruga/src/components/table/Table.vue
@@ -53,6 +53,7 @@
                     <slot name="caption" />
                 </caption>
                 <thead v-if="newColumns.length && showHeader">
+                    <slot name="preheader" />
                     <tr>
                         <th v-if="showDetailRowIcon" :class="thDetailedClasses"/>
                         <th :class="thCheckboxClasses" v-if="checkable && checkboxPosition === 'left'">


### PR DESCRIPTION
## Proposed Changes

This PR adds a slot named `preheader` inside `<thead>` in Table.vue, and mentions it in the documentation.

I see that there is a similar subheading slot feature for `OTableColumn` that is undocumented.  I found it while reading the code, and while I think it's interesting, I believe that the implementation is overly restrictive and overly complicated, so I didn't choose to follow that pattern here.

If a `Table.vue` user has a use case for extra table headers above or below the standard header, I think it's best to hand over full control rather than trying to introduce a limited API like the subheading pattern attempts to do.  For example, I need to add an extra header with `colspan` and special CSS.  The subheading pattern doesn't use `thAttrs`, so it's too restrictive for me. 

IMO the whole custom column subheading slot thing should be replaced with a single, simple slot like mine to allow maximum flexibility for unpredictable needs, but that's definitely out of scope for this PR.

## Documentation

Documented here https://deploy-preview-517--oruga-documentation-preview.netlify.app/components/Table.html#slots

## Example

Here's a screenshot of the table I need to build, which uses the new slot.

<img width="1198" alt="Screenshot 2023-04-20 at 12 05 19 PM" src="https://user-images.githubusercontent.com/4214172/233438117-2e51979d-08af-4fec-9505-9a58ce270240.png">

Thanks for maintaining this library and for taking the time to review my PR!