### PR TITLE
fix(oruga-next): provide node subpath exports

### DIFF
--- a/packages/oruga-next/package.json
+++ b/packages/oruga-next/package.json
@@ -9,6 +9,14 @@
   "module": "dist/esm/index.js",
   "unpkg": "dist/oruga.min.js",
   "typings": "types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js"
+    },
+    "./*": "./*"
+  },
   "files": [
     "dist",
     "src",


### PR DESCRIPTION
Resolves https://github.com/nuxt/nuxt/issues/20627

## Proposed Changes

This adds subpath exports for imports from `@oruga-ui/oruga-next` that work in native Node ESM. (The `module` field is ignored by Node and without this change we will always import the CJS build when `@oruga-ui/oruga-next` is externalized.)