### PR TITLE
better support o-input with input type=number

### DIFF
--- a/packages/oruga-next/src/components/input/Input.vue
+++ b/packages/oruga-next/src/components/input/Input.vue
@@ -8,8 +8,7 @@
             :type="newType"
             :autocomplete="newAutocomplete"
             :maxlength="maxlength"
-            :value="computedValue"
-            @input="onInput"
+            v-model="computedValue"
             @blur="onBlur"
             @focus="onFocus"
             @invalid="onInvalid" />
@@ -20,8 +19,7 @@
             ref="textarea"
             :class="inputClasses"
             :maxlength="maxlength"
-            :value="computedValue"
-            @input="onInput"
+            v-model="computedValue"
             @blur="onBlur"
             @focus="onFocus"
             @invalid="onInvalid"
@@ -303,10 +301,6 @@ export default defineComponent({
             this.$nextTick(() => {
                 this.focus()
             })
-        },
-
-        onInput(event) {
-            this.computedValue = event.target.value
         },
 
         iconClick(emit, event) {


### PR DESCRIPTION
Fixes #526
Fixes #527

## Proposed Changes

This fixes `o-input` with `type=number` (see the linked issues).

Vue doesn't support `modelModifiers` fallthrough to native inputs (see https://github.com/vuejs/core/issues/1825) but simply converting the code to use `v-model` in `o-input` achieves the desired behaviour **and** makes it more consistent with native input.

Besides, the code becomes cleaner. I mean, why introducing a settable computable and not use?
