### PR TITLE
[Autocomplete] Fix issue related to select-header and select-footer events

### DIFF
--- a/packages/oruga-next/src/components/autocomplete/Autocomplete.vue
+++ b/packages/oruga-next/src/components/autocomplete/Autocomplete.vue
@@ -121,7 +121,7 @@ export default defineComponent({
     },
     mixins: [BaseComponentMixin, FormElementMixin],
     inheritAttrs: false,
-    emits: ['update:modelValue', 'select', 'infinite-scroll', 'typing', 'focus', 'blur', 'invalid', 'icon-click', 'icon-right-click'],
+    emits: ['update:modelValue', 'select', 'select-header', 'select-footer', 'infinite-scroll', 'typing', 'focus', 'blur', 'invalid', 'icon-click', 'icon-right-click'],
     props: {
         /** @model */
         modelValue: [Number, String],
@@ -570,7 +570,7 @@ export default defineComponent({
                 if (triggerClick) this.setHovered(null)
                 if (closeDropdown) this.isActive = false
             }
-            if (this.selectableFooter && (this.footerHovered || (triggerClick && triggerClick.origin === 'header'))) {
+            if (this.selectableFooter && (this.footerHovered || (triggerClick && triggerClick.origin === 'footer'))) {
                 this.$emit('select-footer', event)
                 this.footerHovered = false
                 if (triggerClick) this.setHovered(null)


### PR DESCRIPTION
I have made some changes that address the following issues:

1) Missing events in the `emits` array
2) Not triggering `select-footer` event

Please note that I have only tested these changes manually. If you would like me to incorporate any modifications into the automatic tests, please let me know.

Additionally, this is only applicable to the `oruga-next` package. The `oruga` package looks fine to me: https://github.com/oruga-ui/oruga/blob/develop/packages/oruga/src/components/autocomplete/Autocomplete.vue#L568