### PR TITLE
Fix memory leak in MatchMediaMixin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "root",
-  "version": "0.5.10",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "root",
-      "version": "0.5.10",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "conventional-changelog": "^3.1.25",

--- a/packages/oruga-next/src/utils/MatchMediaMixin.ts
+++ b/packages/oruga-next/src/utils/MatchMediaMixin.ts
@@ -11,7 +11,6 @@ export default defineComponent({
     },
     data() {
         return {
-            matchMediaRef: undefined,
             isMatchMedia: undefined
         }
     },
@@ -20,28 +19,24 @@ export default defineComponent({
             this.isMatchMedia = event.matches
         }
     },
-    created() {
-        if (typeof window !== 'undefined') {
-            let width = this.mobileBreakpoint
-            if (!width) {
-                const config = getOptions()
-                const defaultWidth = getValueByPath(config, `mobileBreakpoint`, '1023px')
-                width = getValueByPath(config, `${this.$options.configField}.mobileBreakpoint`, defaultWidth)
-            }
-            this.matchMediaRef = window.matchMedia(`(max-width: ${width})`)
-            if (this.matchMediaRef) {
-                this.isMatchMedia = this.matchMediaRef.matches
-                this.matchMediaRef.addListener(this.onMatchMedia, false)
-            } else {
-                this.isMatchMedia = false
-            }
+    mounted() {
+        let width = this.mobileBreakpoint
+        if (!width) {
+            const config = getOptions()
+            const defaultWidth = getValueByPath(config, `mobileBreakpoint`, '1023px')
+            width = getValueByPath(config, `${this.$options.configField}.mobileBreakpoint`, defaultWidth)
+        }
+        this.$mediaRef = window.matchMedia(`(max-width: ${width})`)
+        if (this.$mediaRef) {
+            this.isMatchMedia = this.$mediaRef.matches
+            this.$mediaRef.addEventListener('change', this.onMatchMedia)
+        } else {
+            this.isMatchMedia = false
         }
     },
-    beforeUnmount() {
-        if (typeof window !== 'undefined') {
-            if (this.matchMediaRef) {
-                this.matchMediaRef.removeListener(this.checkMatchMedia)
-            }
+    unmounted() {
+        if (this.$mediaRef) {
+            this.$mediaRef.removeEventListener('change', this.onMatchMedia)
         }
     }
 })

--- a/packages/oruga/src/utils/MatchMediaMixin.js
+++ b/packages/oruga/src/utils/MatchMediaMixin.js
@@ -1,4 +1,4 @@
-import { getOptions } from '../utils/config'
+import { getOptions } from './config'
 import { getValueByPath } from './helpers'
 
 export default {
@@ -10,37 +10,32 @@ export default {
     },
     data() {
         return {
-            matchMediaRef: undefined,
             isMatchMedia: undefined
-        }
+        };
     },
     methods: {
         onMatchMedia(event) {
             this.isMatchMedia = event.matches
         }
     },
-    created() {
-        if (typeof window !== 'undefined') {
-            let width = this.mobileBreakpoint
-            if (!width) {
-                const config = getOptions()
-                const defaultWidth = getValueByPath(config, `mobileBreakpoint`, '1023px')
-                width = getValueByPath(config, `${this.$options.configField}.mobileBreakpoint`, defaultWidth)
-            }
-            this.matchMediaRef = window.matchMedia(`(max-width: ${width})`)
-            if (this.matchMediaRef) {
-                this.isMatchMedia = this.matchMediaRef.matches
-                this.matchMediaRef.addListener(this.onMatchMedia, false)
-            } else {
-                this.isMatchMedia = false
-            }
+    mounted() {
+        let width = this.mobileBreakpoint
+        if (!width) {
+            const config = getOptions()
+            const defaultWidth = getValueByPath(config, 'mobileBreakpoint', '1023px')
+            width = getValueByPath(config, `${this.$options.configField}.mobileBreakpoint`, defaultWidth)
+        }
+        this.$mediaRef = window.matchMedia(`(max-width: ${width})`)
+        if (this.$mediaRef) {
+            this.isMatchMedia = this.$mediaRef.matches
+            this.$mediaRef.addEventListener('change', this.onMatchMedia)
+        } else {
+            this.isMatchMedia = false
         }
     },
-    beforeDestroy() {
-        if (typeof window !== 'undefined') {
-            if (this.matchMediaRef) {
-                this.matchMediaRef.removeListener(this.checkMatchMedia)
-            }
+    unmounted() {
+        if (this.$mediaRef) {
+            this.$mediaRef.removeEventListener('change', this.onMatchMedia)
         }
     }
 }


### PR DESCRIPTION
Fixes #566

Proposed Changes
- Call correct method for clean up
- Replace lifecycle hooks with browser executed ones
- Store MediaQueryList as a non-reactive reference
- Replace addListener as it's [depricated](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener)
