### PR TITLE
docs(CHANGELOG.md): fix rename props ariaId to contentId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@
 #### Collapse
 
 **Changes props:**
-* rename `contentId` to `ariaId` prop
+* rename `ariaId` to `contentId` prop
 
 #### Datepicker
 


### PR DESCRIPTION
https://github.com/oruga-ui/oruga/blob/04d5cfbafa1c3b23fd5fda610eb947fd0a32f6dd/packages/oruga-next/src/components/collapse/Collapse.vue#L31C5-L31C14

<!-- Thank you for helping Oruga! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

-
-
-
