### PR TITLE
fix(table): reorder params from Object.assign to allow for non-extensible objects

### DIFF
--- a/packages/oruga-next/src/components/table/Table.vue
+++ b/packages/oruga-next/src/components/table/Table.vue
@@ -587,7 +587,7 @@ const tableData = computed(() => {
     // if no customRowKey is given and data are objects, create unique row id for each row
     return props.data.map((row) =>
         !props.customRowKey && typeof row === "object"
-            ? Object.assign(row, { __rowKey: uuid() })
+            ? Object.assign({ __rowKey: uuid() }, row)
             : row,
     );
 });


### PR DESCRIPTION
Non-extensible objects (such as VueJS computed properties) don't allow to be extended with Object.assign(). By inverting the two parameters, we copy all the properties of the row to the new `{ __rowKey: uuid() }` object instead.

Fixes `TypeError: can't define property "__rowKey": Object is not extensible`