### PR TITLE
fix(autocomplete): change input vbind vmodel prop order

### DIFF
--- a/packages/oruga-next/src/components/autocomplete/Autocomplete.vue
+++ b/packages/oruga-next/src/components/autocomplete/Autocomplete.vue
@@ -787,8 +787,8 @@ function itemOptionClasses(option): PropBind {
         <template #trigger>
             <o-input
                 ref="inputRef"
-                v-model="vmodel"
                 v-bind="inputBind"
+                v-model="vmodel"
                 :type="type"
                 :size="size"
                 :rounded="rounded"


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #704
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Change autocomplete internal input v-bind / v-model prop order