### PR TITLE
fix(taginput): watch TagInput v-model prop with deep in order to trigger update:modelValue event

### DIFF
--- a/packages/oruga-next/src/components/taginput/Taginput.vue
+++ b/packages/oruga-next/src/components/taginput/Taginput.vue
@@ -266,7 +266,7 @@ const emits = defineEmits<{
 
 const autocompleteRef = ref<InstanceType<typeof OAutocomplete>>();
 
-const items = useVModelBinding<any[]>(props, emits, { passive: true });
+const items = useVModelBinding<any[]>(props, emits, { passive: true, deep: true });
 
 // use form input functionalities
 const { setFocus, onFocus, onBlur, onInvalid } = useInputHandler(


### PR DESCRIPTION
Unless the `deep` option is being specified, the `update:modelValue` event is not triggered by the `TagInput` component (only the `add`/`remove` events are).

There may be another way of fixing this, I'm not familiar with this `useVModelBinding` pattern. Other components may be affected by similar issues, I didn't test them.