### PR TITLE
pass missing placeholder and validationMessage props to autocomplete component 

### DIFF
--- a/packages/oruga-next/src/components/taginput/Taginput.vue
+++ b/packages/oruga-next/src/components/taginput/Taginput.vue
@@ -501,6 +501,7 @@ const counterClasses = computed(() => [
                 :check-scroll="checkScroll"
                 :teleport="teleport"
                 :confirm-keys="confirmKeys"
+                :placeholder="placeholder"
                 @input="onInput"
                 @focus="onFocus"
                 @blur="handleOnBlur"

--- a/packages/oruga-next/src/components/taginput/Taginput.vue
+++ b/packages/oruga-next/src/components/taginput/Taginput.vue
@@ -502,6 +502,7 @@ const counterClasses = computed(() => [
                 :teleport="teleport"
                 :confirm-keys="confirmKeys"
                 :placeholder="placeholder"
+                :validation-message="validationMessage"
                 @input="onInput"
                 @focus="onFocus"
                 @blur="handleOnBlur"


### PR DESCRIPTION
I noticed you can't set a placeholder on the input item from the TagInput component