### PR TITLE
fix: update config ClassFunction second parameter from context to props

### DIFF
--- a/packages/docs-next/documentation/customisation.md
+++ b/packages/docs-next/documentation/customisation.md
@@ -90,19 +90,19 @@ createApp(...)
     });
 ```
 
-For a better customisation experience, this function accepts the component's `context` containing its read-only attributes (`props`, `data` and `computed`) as a second parameter. For example using [Bootstrap](https://getbootstrap.com/) you may want to apply variants to buttons only when the element is not outlined:
+For a better customisation experience, this function accepts the component's read-only `props` as a second parameter. For example using [Bootstrap](https://getbootstrap.com/) you may want to apply variants to buttons only when the element is not outlined:
 
 ```js
 createApp(...)
     .use(Oruga, {
         input: {
-            rootClass: (_, context) => {
-                if (context.computed.hasIconRight) {
+            rootClass: (_, props) => {
+                if (props.iconRight) {
                     return 'has-icons-right';
                 }
             },
-            variantClass: (variant, context) => {
-                if (!context.props.outlined) {
+            variantClass: (variant, props) => {
+                if (!props.outlined) {
                     return `btn-${variant}`;
                 }
             }

--- a/packages/oruga-next/src/types/config.ts
+++ b/packages/oruga-next/src/types/config.ts
@@ -2,15 +2,11 @@ import type { ValidatableFormElement } from "@/composables";
 import type { IconConfig } from "@/utils/icons";
 import type { DynamicComponent } from "./utils";
 
-export type ComponentContext = {
-    props: Record<string, any>;
-    data: Record<string, any>;
-    computed: Record<string, any>;
-};
+export type ComponentProps = Record<string, any>;
 
 export type ClassFunction = (
     suffix: string,
-    ctx: ComponentContext,
+    props: ComponentProps,
 ) => string | undefined;
 
 export type ClassObject = {

--- a/packages/oruga-next/src/utils/helpers.ts
+++ b/packages/oruga-next/src/utils/helpers.ts
@@ -211,10 +211,6 @@ export function escapeRegExpChars(value: string): string {
     return value.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
 }
 
-export function endsWith(str: string, suffix: string): boolean {
-    return str.indexOf(suffix, str.length - suffix.length) !== -1;
-}
-
 export function toCssDimension(width: string | number): string | number {
     return width === undefined
         ? null


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Using the composition api, the `$data` and `$computed` attributes are no longer available on a component instance. 
Therefore they can't be used for the second parameter of the `ClassFunction` theme config. 

Since the ComponentContext then only contains the component props, I pass the props directly as the second parameter of the function. 

## Proposed Changes

- update ComponentContext to ComponentProps
