### PR TITLE
fix(taginput): forward expanded prop to Autocomplete component so that it's passed to dropdown

### DIFF
--- a/packages/oruga-next/src/components/taginput/Taginput.vue
+++ b/packages/oruga-next/src/components/taginput/Taginput.vue
@@ -513,6 +513,7 @@ const counterClasses = defineClasses(["counterClass", "o-taginput__counter"]);
                 :confirm-keys="confirmKeys"
                 :placeholder="placeholder"
                 :validation-message="validationMessage"
+                :expanded="expanded"
                 @input="onInput"
                 @focus="onFocus"
                 @blur="handleOnBlur"


### PR DESCRIPTION
Otherwise it does pretty much nothing apart from allowing to use the `expandedClass`.

| Before | After |
|--------|--------|
| ![image](https://github.com/oruga-ui/oruga/assets/2197836/992d4913-3ea9-4e52-b118-766c7154880a) | ![image](https://github.com/oruga-ui/oruga/assets/2197836/3642db5c-e2b0-438e-b139-ad02c4b608bb) |

(when expanded has been hardcoded in the example in question)