### PR TITLE
Fix: #355 Tabs Animation on clicking previous tab is broken

### DIFF
--- a/packages/oruga-next/src/components/tabs/Tabs.vue
+++ b/packages/oruga-next/src/components/tabs/Tabs.vue
@@ -246,7 +246,7 @@ function clickFirstViableChild(startingIndex: number, forward: boolean): void {
 function performAction(newId: number | string): void {
     const oldValue = activeId.value;
     const oldTab = isDefined(oldValue)
-        ? items.value.find((item) => item.value === oldValue)[0]
+        ? items.value.find((item) => item.value === oldValue)
         : items.value[0];
     activeId.value = newId;
     nextTick(() => {


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #355

## Proposed Changes

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find

> The find() method of [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) instances returns the first element in the provided array that satisfies the provided testing function.

So, removed index from result of Array.find() in performAction().