### PR TITLE
fix(autocomplete): show empty slot available

### DIFF
--- a/packages/oruga-next/src/components/autocomplete/Autocomplete.vue
+++ b/packages/oruga-next/src/components/autocomplete/Autocomplete.vue
@@ -442,7 +442,7 @@ const isEmpty = computed(
 );
 
 watch(isEmpty, (empty) => {
-    if (isFocused) isActive.value = !empty;
+    if (isFocused.value) isActive.value = !empty || !!slots.empty;
 });
 
 const closeableOptions = computed(() => {
@@ -932,7 +932,7 @@ function itemOptionClasses(option): ClassBind[] {
             :tag="itemTag"
             :class="[...itemClasses, ...itemEmptyClasses]">
             <!--
-                @slot Define content for empty state 
+                @slot Define content for empty state
             -->
             <slot name="empty" />
         </o-dropdown-item>


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

This fixes an issue encountered while testing https://github.com/oruga-ui/oruga/pull/777 where the autocomplete does not display the contents of the empty slot when there are no results.

