### PR TITLE
Bugfix : Restore focus() method

### DIFF
--- a/packages/oruga-next/src/components/autocomplete/Autocomplete.vue
+++ b/packages/oruga-next/src/components/autocomplete/Autocomplete.vue
@@ -674,6 +674,10 @@ function handleFocus(event: Event): void {
     onFocus(event);
 }
 
+function focus(): void {
+    inputRef.value.focus();
+}
+
 /**
  * Blur listener.
  * Close on blur.
@@ -720,7 +724,7 @@ function rightIconClick(event: Event): void {
     if (props.clearable) {
         vmodel.value = "";
         setSelected(null, false);
-        if (props.openOnFocus) inputRef.value.$el.focus();
+        if (props.openOnFocus) focus();
     } else emits("icon-right-click", event);
 }
 
@@ -797,6 +801,10 @@ function itemOptionClasses(option): ClassBind[] {
 
     return [...itemClasses.value, ...optionClasses.value];
 }
+
+defineExpose({
+    focus,
+});
 </script>
 
 <template>
@@ -932,7 +940,7 @@ function itemOptionClasses(option): ClassBind[] {
             :tag="itemTag"
             :class="[...itemClasses, ...itemEmptyClasses]">
             <!--
-                @slot Define content for empty state 
+                @slot Define content for empty state
             -->
             <slot name="empty" />
         </o-dropdown-item>

--- a/packages/oruga-next/src/components/input/Input.vue
+++ b/packages/oruga-next/src/components/input/Input.vue
@@ -442,6 +442,14 @@ const iconRightClasses = defineClasses([
 ]);
 
 const counterClasses = defineClasses(["counterClass", "o-input__counter"]);
+
+function focus(): void {
+    setFocus();
+}
+
+defineExpose({
+    focus,
+});
 </script>
 
 <template>


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Prior to Oruga 0.8.0 input and autocomplete had focus() methods to allow the input to be focused from the parent. This PR restores those methods.

## Proposed Changes

- `focus()` method added to Input and Autocomplete.
