### PR TITLE
fix(input): update password reveal 

### DIFF
--- a/packages/oruga-next/src/components/input/Input.vue
+++ b/packages/oruga-next/src/components/input/Input.vue
@@ -365,6 +365,14 @@ function rightIconClick(event: Event): void {
 const isPasswordVisible = ref(false);
 const inputType = ref(props.type);
 
+const computedInputType = computed(() => {
+    if (props.passwordReveal) {
+        return isPasswordVisible.value ? "input" : "password";
+    } else {
+        return inputType.value;
+    }
+});
+
 // update inputType on type prop change
 watch(
     () => props.type,
@@ -382,7 +390,6 @@ const passwordVisibleIcon = computed(() =>
  */
 function togglePasswordVisibility(): void {
     isPasswordVisible.value = !isPasswordVisible.value;
-    inputType.value = isPasswordVisible.value ? "text" : "password";
     nextTick(() => setFocus());
 }
 
@@ -461,7 +468,7 @@ const counterClasses = defineClasses(["counterClass", "o-input__counter"]);
             ref="inputRef"
             v-model="vmodel"
             :data-oruga-input="inputType"
-            :type="inputType"
+            :type="computedInputType"
             :class="inputClasses"
             :maxlength="maxlength"
             :autocomplete="autocomplete"

--- a/packages/oruga-next/src/components/input/Input.vue
+++ b/packages/oruga-next/src/components/input/Input.vue
@@ -367,7 +367,7 @@ const inputType = ref(props.type);
 
 const computedInputType = computed(() => {
     if (props.passwordReveal) {
-        return isPasswordVisible.value ? "input" : "password";
+        return isPasswordVisible.value ? "text" : "password";
     } else {
         return inputType.value;
     }

--- a/packages/oruga-next/src/components/input/Input.vue
+++ b/packages/oruga-next/src/components/input/Input.vue
@@ -363,21 +363,14 @@ function rightIconClick(event: Event): void {
 // --- Password Visability Feature ---
 
 const isPasswordVisible = ref(false);
-const inputType = ref(props.type);
 
-const computedInputType = computed(() => {
+const inputType = computed(() => {
     if (props.passwordReveal) {
         return isPasswordVisible.value ? "text" : "password";
     } else {
-        return inputType.value;
+        return props.type;
     }
 });
-
-// update inputType on type prop change
-watch(
-    () => props.type,
-    (type) => (inputType.value = type),
-);
 
 /** Current password-reveal icon name. */
 const passwordVisibleIcon = computed(() =>
@@ -468,7 +461,7 @@ const counterClasses = defineClasses(["counterClass", "o-input__counter"]);
             ref="inputRef"
             v-model="vmodel"
             :data-oruga-input="inputType"
-            :type="computedInputType"
+            :type="inputType"
             :class="inputClasses"
             :maxlength="maxlength"
             :autocomplete="autocomplete"


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes an issue encountered while testing https://github.com/oruga-ui/oruga/pull/777 where if the password reveal prop was set the password would not be hidden when the component initially loaded. Subsequently clicking the show/hide icon would work correctly.
