### PR TITLE
fix(composable): prevent scrolling parent error with parent null

### DIFF
--- a/packages/oruga-next/src/composables/useScrollingParent.ts
+++ b/packages/oruga-next/src/composables/useScrollingParent.ts
@@ -1,3 +1,5 @@
+import { isDefined } from "@/utils/helpers";
+
 /**
  * Given an element, returns the element who scrolls it.
  */
@@ -8,7 +10,7 @@ export function getScrollingParent(target: HTMLElement): HTMLElement {
     let isScrollingParent = false;
     let nextParent = target.parentElement;
 
-    while (!isScrollingParent) {
+    while (!isScrollingParent && isDefined(nextParent)) {
         if (nextParent === document.documentElement) break;
 
         const { overflow, overflowY } = getComputedStyle(nextParent);


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #742
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- add `isDefined` check for `nextParent` in `getScrollingParent` composable