### PR TITLE
fix passwordVisibleIcon

### DIFF
--- a/packages/oruga-next/src/components/input/Input.vue
+++ b/packages/oruga-next/src/components/input/Input.vue
@@ -380,7 +380,7 @@ const inputType = computed(() => {
 
 /** Current password-reveal icon name. */
 const passwordVisibleIcon = computed(() =>
-    !isPasswordVisible.value ? "eye" : "eye-off",
+    !isPasswordVisible.value ? "eye-off" : "eye",
 );
 
 /**


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #800 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Change the password visible icon to `eye`
-Change the password invisible icon to `eye-off`