### PR TITLE
Bugfix: Autocomplete results not displayed in initial empty state

### DIFF
--- a/packages/oruga/src/components/autocomplete/Autocomplete.vue
+++ b/packages/oruga/src/components/autocomplete/Autocomplete.vue
@@ -385,6 +385,9 @@ watch(
                 else if (isFocused.value && (!props.openOnFocus || value))
                     isActive.value = !!value;
             });
+        } else {
+            // Open if you have search string but no results and empty template is present
+            if (!!slots.empty && isEmpty.value) isActive.value = !!value;
         }
     },
 );


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Prior to Oruga 0.8.0 the autocomplete would display the contents of the empty slot as soon as the user typed something and no results were found. As of Oruga 0.8.0, the empty slot's contents are not displayed until a result is found, after which empty will be displayed.

### Detailed reproduction instructions
Consider the following page:
```
<template>
	<o-autocomplete
		v-model="autocompleteQuery"
		:data="autocompleteResults"
	>
		<template #empty>
			No results found
		</template>
	</o-autocomplete>
</template>

<script lang="ts">
import { defineComponent } from 'vue';

export default defineComponent({
	data() {
		return {
			autocompleteQuery: '',
			autocompleteOptions: ['foo', 'bar', 'fiz'],
		};
	},
	computed: {
		autocompleteResults(): string[] {
			if (!this.autocompleteQuery) return [];
			return this.autocompleteOptions
				.filter(option => option.includes(this.autocompleteQuery))
				.slice(0, 4);
		},
	},
});
</script>
```

Expectations: Once the user starts typing, the empty slot should be displayed if autocompleteResults is an empty array.

Reality: When you load the page, if you enter a string which does not match (ex "qqq"), the empty slot will not be displayed. If you then delete "qqq" and type something which does match like "fiz", you'll see the matching result and afterwards you'll see the "No results found" message if you delete "fiz" and type "qqq" again.

WTF is happening?: `isActive` controls whether the autocomplete dropdown is open. This ref is primarily manipulated by a watcher on `isEmpty`. Any time `isEmpty` changes the watcher adjusts `isActive`. However, in this example the results begin empty and continue to empty as the user types "qqq", so the watcher doesn't fire until we get a match with "fiz", making `isEmpty` false and firing the watcher.

## Proposed Changes

- Adds to the existing vmodel watcher and opens the results if the user has typed something, the empty slot is present and there are no results.
