### PR TITLE
fix(autocomplete): update type declaration for selected value in Autocomplete events

### DIFF
--- a/packages/docs/components/Autocomplete.md
+++ b/packages/docs/components/Autocomplete.md
@@ -85,20 +85,20 @@ title: Autocomplete
 
 ### Events
 
-| Event name        | Properties                                             | Description                                    |
-| ----------------- | ------------------------------------------------------ | ---------------------------------------------- |
-| icon-click        | **event** `Event` - native event                       | on icon click event                            |
-| update:modelValue | **value** `string \| number` - updated modelValue prop | modelValue prop two-way binding                |
-| input             | **value** `string \| number` - input value             | on input change event                          |
-| select            | **value** `string \| number` - selected value          | selected element changed event                 |
-| select-header     | **event** `Event` - native event                       | header is selected                             |
-| select-footer     | **event** `Event` - native event                       | footer is selected                             |
-| focus             | **event** `Event` - native event                       | on input focus event                           |
-| blur              | **event** `Event` - native event                       | on input blur event                            |
-| invalid           | **event** `Event` - native event                       | on input invalid event                         |
-| icon-right-click  | **event** `Event` - native event                       | on icon right click event                      |
-| scroll-start      |                                                        | the list inside the dropdown reached the start |
-| scroll-end        |                                                        | the list inside the dropdown reached it's end  |
+| Event name        | Properties                                                       | Description                                    |
+| ----------------- | ---------------------------------------------------------------- | ---------------------------------------------- |
+| icon-click        | **event** `Event` - native event                                 | on icon click event                            |
+| update:modelValue | **value** `string \| number \| object` - updated modelValue prop | modelValue prop two-way binding                |
+| input             | **value** `string \| number` - input value                       | on input change event                          |
+| select            | **value** `string \| number \| object` - selected value          | selected element changed event                 |
+| select-header     | **event** `Event` - native event                                 | header is selected                             |
+| select-footer     | **event** `Event` - native event                                 | footer is selected                             |
+| focus             | **event** `Event` - native event                                 | on input focus event                           |
+| blur              | **event** `Event` - native event                                 | on input blur event                            |
+| invalid           | **event** `Event` - native event                                 | on input invalid event                         |
+| icon-right-click  | **event** `Event` - native event                                 | on icon right click event                      |
+| scroll-start      |                                                                  | the list inside the dropdown reached the start |
+| scroll-end        |                                                                  | the list inside the dropdown reached it's end  |
 
 ### Slots
 

--- a/packages/oruga/src/components/autocomplete/Autocomplete.vue
+++ b/packages/oruga/src/components/autocomplete/Autocomplete.vue
@@ -277,9 +277,9 @@ const props = defineProps({
 const emits = defineEmits<{
     /**
      * modelValue prop two-way binding
-     * @param value {string | number} updated modelValue prop
+     * @param value {string | number | object} updated modelValue prop
      */
-    (e: "update:modelValue", value: string | number): void;
+    (e: "update:modelValue", value: string | number | object): void;
     /**
      * on input change event
      * @param value {string | number} input value
@@ -287,9 +287,9 @@ const emits = defineEmits<{
     (e: "input", value: string | number): void;
     /**
      * selected element changed event
-     * @param value {string | number} selected value
+     * @param value {string | number | object} selected value
      */
-    (e: "select", value: string | number, evt: Event): void;
+    (e: "select", value: string | number | object, evt: Event): void;
     /**
      * header is selected
      * @param event {Event} native event


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

This fixes a small problem with the autocomplete options/suggestions passed as an array of objects when the `field` prop is not being set. The proposed change is to allow an object as a potential value type. This change aims to prevent linter warnings that occur when binding `update:modelValue` and `select` events:

![image](https://github.com/oruga-ui/oruga/assets/11018286/f9406e88-2db6-4b18-808f-532bd9a4f091)

I'm unsure if this is the right approach or not, so I'm open to suggestions.
