### PR TITLE
Bugfix: Remove toRaw from TableColumn data provider when providing props

### DIFF
--- a/packages/oruga/src/components/table/TableColumn.vue
+++ b/packages/oruga/src/components/table/TableColumn.vue
@@ -89,6 +89,7 @@ const vm = getCurrentInstance();
 
 const providedData = computed<TableColumnComponent>(() => ({
     ...toRaw(props),
+    visible: props.visible,
     $el: vm.proxy,
     $slots: vm.slots,
     style: style.value,


### PR DESCRIPTION
Fixes oruga-ui/oruga/issues#876

Fixes #876 

## Proposed Changes
Remove toRaw when providing property data to restore reactivity to prop changes.