### PR TITLE
fix(table): make `TableColumn` props reactive again

### DIFF
--- a/packages/oruga/src/components/table/TableColumn.vue
+++ b/packages/oruga/src/components/table/TableColumn.vue
@@ -63,12 +63,18 @@ const props = defineProps({
     sticky: { type: Boolean, default: false },
     /** Make header selectable */
     headerSelectable: { type: Boolean, default: false },
-    /** Adds native attributes to th */
+    /**
+     * Adds native attributes to th
+     * @deprecated will be moved to table component
+     */
     thAttrs: {
         type: Function as PropType<(column: typeof props) => object>,
         default: () => ({}),
     },
-    /** Adds native attributes to td */
+    /**
+     * Adds native attributes to td
+     * @deprecated will be moved to table component
+     */
     tdAttrs: {
         type: Function as PropType<
             (row: unknown, column: typeof props) => object
@@ -88,7 +94,21 @@ const isHeaderUnselectable = computed(
 const vm = getCurrentInstance();
 
 const providedData = computed<TableColumnComponent>(() => ({
-    ...toRaw(props),
+    ...toRaw(props), // TODO: remove toRaw when tdAttrs/thAttrs are moved to table component
+    label: props.label,
+    field: props.field,
+    subheading: props.subheading,
+    meta: props.meta,
+    width: props.width,
+    numeric: props.numeric,
+    position: props.position,
+    searchable: props.searchable,
+    sortable: props.sortable,
+    visible: props.visible,
+    customSort: props.customSort,
+    customSearch: props.customSearch,
+    sticky: props.sticky,
+    headerSelectable: props.headerSelectable,
     $el: vm.proxy,
     $slots: vm.slots,
     style: style.value,

--- a/packages/oruga/src/components/table/TableColumn.vue
+++ b/packages/oruga/src/components/table/TableColumn.vue
@@ -65,7 +65,7 @@ const props = defineProps({
     headerSelectable: { type: Boolean, default: false },
     /**
      * Adds native attributes to th
-     * @deprecated will be moved to table component
+     * @deprecated will be moved to table component in v0.9
      */
     thAttrs: {
         type: Function as PropType<(column: typeof props) => object>,
@@ -73,7 +73,7 @@ const props = defineProps({
     },
     /**
      * Adds native attributes to td
-     * @deprecated will be moved to table component
+     * @deprecated will be moved to table component in v0.9
      */
     tdAttrs: {
         type: Function as PropType<


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Part of #876 (no solved in detail)
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- make table-column props reactive again (beside tdAttrs/thAttrs)
- deprecate tdAttrs/thAttrs on table-column (will be moved to table)