### PR TITLE
fix(step|tab): make item props reactive again

### DIFF
--- a/packages/oruga/src/components/steps/StepItem.vue
+++ b/packages/oruga/src/components/steps/StepItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, toRaw, ref, useSlots, type PropType } from "vue";
+import { computed, ref, useSlots, type PropType } from "vue";
 
 import { getOption } from "@/utils/config";
 import { isEqual, uuid } from "@/utils/helpers";
@@ -100,7 +100,7 @@ const emits = defineEmits<{
 const slots = useSlots();
 
 const providedData = computed<StepItemComponent>(() => ({
-    ...toRaw(props),
+    ...props,
     $slots: slots,
     isTransitioning: isTransitioning.value,
     activate,

--- a/packages/oruga/src/components/tabs/TabItem.vue
+++ b/packages/oruga/src/components/tabs/TabItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, toRaw, ref, useSlots, type PropType } from "vue";
+import { computed, ref, useSlots, type PropType } from "vue";
 
 import { getOption } from "@/utils/config";
 import { isEqual, uuid } from "@/utils/helpers";
@@ -99,7 +99,7 @@ const emits = defineEmits<{
 const slots = useSlots();
 
 const providedData = computed<TabItemComponent>(() => ({
-    ...toRaw(props),
+    ...props,
     $slots: slots,
     headerIconClasses: headerIconClasses.value,
     headerTextClasses: headerTextClasses.value,


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Found by #876 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- remove `toRaw` from computed provided item data to make the props reactive again

