### PR TITLE
fix(datepicker): make date parsing work again

### DIFF
--- a/packages/oruga/src/components/datepicker/Datepicker.vue
+++ b/packages/oruga/src/components/datepicker/Datepicker.vue
@@ -852,13 +852,15 @@ function formatNative(value: Date | Date[]): string {
 /** Parse string into date */
 function onChange(value: string): void {
     const date = (props.dateParser as any)(value, defaultDateParser);
+    const validDate = (d: unknown): d is Date =>
+        d instanceof Date && !isNaN(d.getTime());
 
     if (
-        date instanceof Date ||
+        validDate(date) ||
         (Array.isArray(date) &&
             date.length === 2 &&
-            date[0] instanceof Date &&
-            date[1] instanceof Date)
+            validDate(date[0]) &&
+            validDate(date[1]))
     ) {
         vmodel.value = date;
     } else {

--- a/packages/oruga/src/components/datepicker/Datepicker.vue
+++ b/packages/oruga/src/components/datepicker/Datepicker.vue
@@ -854,11 +854,11 @@ function onChange(value: string): void {
     const date = (props.dateParser as any)(value, defaultDateParser);
 
     if (
-        date &&
-        Array.isArray(date) &&
-        date.length === 2 &&
-        !isNaN(date[0]) &&
-        !isNaN(date[1])
+        date instanceof Date ||
+        (Array.isArray(date) &&
+            date.length === 2 &&
+            date[0] instanceof Date &&
+            date[1] instanceof Date)
     ) {
         vmodel.value = date;
     } else {

--- a/packages/oruga/src/components/datepicker/tests/datepicker.test.ts
+++ b/packages/oruga/src/components/datepicker/tests/datepicker.test.ts
@@ -22,4 +22,18 @@ describe("ODatepicker", () => {
             "2024-04-10T00:00:00.000Z",
         );
     });
+
+    test("handles invalid keyboard input", () => {
+        const wrapper = mount(ODatepicker, { props: { readonly: false } });
+
+        const target = wrapper.find("input");
+        expect(target.exists()).toBeTruthy();
+        target.setValue("not-a-date");
+
+        const updates = wrapper.emitted("update:modelValue");
+        expect(updates).toHaveLength(1);
+        expect(updates[0]).toHaveLength(1);
+        const updateValue = updates[0][0];
+        expect(updateValue).toBeNull();
+    });
 });

--- a/packages/oruga/src/components/datepicker/tests/datepicker.test.ts
+++ b/packages/oruga/src/components/datepicker/tests/datepicker.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { mount, enableAutoUnmount } from "@vue/test-utils";
+
+import ODatepicker from "@/components/datepicker/Datepicker.vue";
+
+describe("ODatepicker", () => {
+    enableAutoUnmount(afterEach);
+
+    test("parses keyboard input", () => {
+        const wrapper = mount(ODatepicker, { props: { readonly: false } });
+
+        const target = wrapper.find("input");
+        expect(target.exists()).toBeTruthy();
+        target.setValue("2024-04-10");
+
+        const updates = wrapper.emitted("update:modelValue");
+        expect(updates).toHaveLength(1);
+        expect(updates[0]).toHaveLength(1);
+        const updateValue = updates[0][0];
+        expect(updateValue).toBeInstanceOf(Date);
+        expect((updateValue as Date).toISOString()).toBe(
+            "2024-04-10T00:00:00.000Z",
+        );
+    });
+});


### PR DESCRIPTION
Fixes #881

## Proposed Changes

- Accept plain dates in `onChange`, not just date-range pairs

Note that parsing of date ranges is still broken; it collapses them to a single date.
That seems like a separate bug, though.
