### PR TITLE
feat(taginput): add removeItem as selected slot property (#887)

### DIFF
--- a/packages/docs/.vitepress/theme/examples/taginput/custom-selected.vue
+++ b/packages/docs/.vitepress/theme/examples/taginput/custom-selected.vue
@@ -27,7 +27,7 @@ function getType(item) {
                 v-model="items"
                 icon="tag"
                 placeholder="Add an item">
-                <template #selected="{ items }">
+                <template #selected="{ items, removeItem }">
                     <o-button
                         v-for="(item, index) in items"
                         :key="index"
@@ -35,7 +35,7 @@ function getType(item) {
                         native-type="button"
                         :variant="getType(item)"
                         rounded
-                        @click="$refs.input.removeItem(index, $event)" />
+                        @click="removeItem(index, $event)" />
                 </template>
             </o-taginput>
         </o-field>

--- a/packages/oruga/src/components/taginput/Taginput.vue
+++ b/packages/oruga/src/components/taginput/Taginput.vue
@@ -475,7 +475,7 @@ const counterClasses = defineClasses(["counterClass", "o-taginput__counter"]);
 // --- Expose Public Functionalities ---
 
 /** expose functionalities for programmatic usage */
-defineExpose({ focus: setFocus });
+defineExpose({ focus: setFocus, removeItem: removeItem });
 </script>
 
 <template>

--- a/packages/oruga/src/components/taginput/Taginput.vue
+++ b/packages/oruga/src/components/taginput/Taginput.vue
@@ -475,7 +475,7 @@ const counterClasses = defineClasses(["counterClass", "o-taginput__counter"]);
 // --- Expose Public Functionalities ---
 
 /** expose functionalities for programmatic usage */
-defineExpose({ focus: setFocus, removeItem: removeItem });
+defineExpose({ focus: setFocus });
 </script>
 
 <template>

--- a/packages/oruga/src/components/taginput/Taginput.vue
+++ b/packages/oruga/src/components/taginput/Taginput.vue
@@ -485,7 +485,7 @@ defineExpose({ focus: setFocus });
                 @slot Override selected items
                 @binding {unknown[]} items - selected items
             -->
-            <slot name="selected" :items="items">
+            <slot name="selected" :items="items" :remove-item="removeItem">
                 <span
                     v-for="(item, index) in items"
                     :key="getNormalizedItemText(item) + index"


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #887
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes
- Adds `removeItem` to `defineExpose` in `Taginput.vue` so that custom items can call it in their click event to remove the item.
