### PR TITLE
fix(taginput): selection with autocomplete on non string items

### DIFF
--- a/packages/oruga/src/components/taginput/Taginput.vue
+++ b/packages/oruga/src/components/taginput/Taginput.vue
@@ -115,13 +115,13 @@ const props = defineProps({
     },
     /** Function to validate the value of the item before adding */
     beforeAdding: {
-        type: Function as PropType<(value: string) => boolean>,
+        type: Function as PropType<(value: any) => boolean>,
         default: () => true,
     },
     /** Function to create a new item to push into v-model (items) */
     createItem: {
-        type: Function as PropType<(value: string) => T>,
-        default: (item: string) => item,
+        type: Function as PropType<(value: any) => T>,
+        default: (item: any) => item,
     },
     /** Makes the component check if list reached scroll start or end and emit scroll events. */
     checkScroll: {
@@ -340,8 +340,8 @@ function getNormalizedItemText(item: T): string {
 function addItem(item?: T | string): void {
     item = item || newItem.value.trim();
 
-    if (item && typeof item === "string") {
-        if (!props.allowAutocomplete) {
+    if (item ) {
+        if (typeof item === "string") {
             const reg = separatorsAsRegExp.value;
             if (reg && item.match(reg)) {
                 item.split(reg)
@@ -536,7 +536,7 @@ defineExpose({ focus: setFocus });
                 @keydown="onKeydown"
                 @compositionstart="isComposing = true"
                 @compositionend="isComposing = false"
-                @select="onSelect($event)"
+                @select="onSelect"
                 @scroll-start="$emit('scroll-start')"
                 @scroll-end="$emit('scroll-end')"
                 @icon-click="$emit('icon-click', $event)"


### PR DESCRIPTION

Fixes #886 

## Proposed Changes

Changes to `addItem` function to fix selection with autocomplete and non string items.

Changes to `createItem` and `beforeAdding`  to be used with any input type, I though it could be left open to the developer to use a transform or validation function for any type while using autocomplete.
