### PR TITLE
fix(Menu): ref unwrapping error

### DIFF
--- a/packages/oruga/src/components/menu/Menu.vue
+++ b/packages/oruga/src/components/menu/Menu.vue
@@ -95,7 +95,8 @@ const { childItems } = useProviderParent<MenuItemComponent>(rootRef, {
 
 function resetMenu(excludedItems: ProviderItem[] = []): void {
     childItems.value.forEach((item) => {
-        if (!excludedItems.includes(toRaw(item))) item.data.value.reset();
+        // @ts-ignore
+        if (!excludedItems.includes(toRaw(item))) item.data.reset();
     });
 }
 

--- a/packages/oruga/src/components/menu/Menu.vue
+++ b/packages/oruga/src/components/menu/Menu.vue
@@ -95,8 +95,7 @@ const { childItems } = useProviderParent<MenuItemComponent>(rootRef, {
 
 function resetMenu(excludedItems: ProviderItem[] = []): void {
     childItems.value.forEach((item) => {
-        // @ts-ignore
-        if (!excludedItems.includes(toRaw(item))) item.data.reset();
+        if (!excludedItems.includes(toRaw(item))) (item.data as any as MenuItemComponent).reset();
     });
 }
 


### PR DESCRIPTION
Fixes #885 

## Proposed Changes

This is a quick fix to make Menu work again but there is a typescript error that I don't understand and I needed to add a ts ignore line.
I think this is a problem with automatic unwrapping of ref. 
I tried to mimic the part of code in a simple vue script and ts got it right and applied the unwrapping of ref, I don't understand what get TypeScript to behaves differently with oruga code.