### PR TITLE
fix(menu): fix `useProviderParent` composable `childItems` type problem

### DIFF
--- a/packages/oruga/src/components/menu/Menu.vue
+++ b/packages/oruga/src/components/menu/Menu.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, toRaw, type PropType } from "vue";
+import { ref, computed, type PropType } from "vue";
 
 import { getOption } from "@/utils/config";
 import {
@@ -95,7 +95,8 @@ const { childItems } = useProviderParent<MenuItemComponent>(rootRef, {
 
 function resetMenu(excludedItems: ProviderItem[] = []): void {
     childItems.value.forEach((item) => {
-        if (!excludedItems.includes(toRaw(item))) item.data.value.reset();
+        if (!excludedItems.map((i) => i?.identifier).includes(item.identifier))
+            item.data.reset();
     });
 }
 

--- a/packages/oruga/src/composables/useParentProvider.ts
+++ b/packages/oruga/src/composables/useParentProvider.ts
@@ -9,6 +9,7 @@ import {
     type Component,
     type ComputedRef,
     type Ref,
+    type UnwrapNestedRefs,
 } from "vue";
 import { unrefElement } from "./unrefElement";
 
@@ -46,8 +47,8 @@ export function useProviderParent<ItemData = unknown, ParentData = unknown>(
     rootRef?: Ref<HTMLElement | Component>,
     options?: ProviderParentOptions<ParentData>,
 ): {
-    childItems: Ref<ProviderItem<ItemData>[]>;
-    sortedItems: Ref<ProviderItem<ItemData>[]>;
+    childItems: Ref<UnwrapNestedRefs<ProviderItem<ItemData>[]>>;
+    sortedItems: ComputedRef<UnwrapNestedRefs<ProviderItem<ItemData>[]>>;
 } {
     // getting a hold of the internal instance in setup()
     const vm = getCurrentInstance();
@@ -59,11 +60,8 @@ export function useProviderParent<ItemData = unknown, ParentData = unknown>(
     const configField = vm.proxy?.$options.configField;
     const key = options?.key ? options.key : configField;
 
-    const childItems = ref<ProviderItem<ItemData>[]>([]) as Ref<
-        ProviderItem<ItemData>[]
-    >;
+    const childItems = ref<ProviderItem<ItemData>[]>([]);
     const sequence = ref(1);
-
     /**
      * When items are added/removed sort them according to their position
      */
@@ -77,7 +75,7 @@ export function useProviderParent<ItemData = unknown, ParentData = unknown>(
         const index = childItems.value.length;
         const identifier = nextSequence();
         const item = { index, data, identifier };
-        childItems.value.push(item);
+        childItems.value.push(item as UnwrapNestedRefs<typeof item>);
         if (rootRef?.value) {
             nextTick(() => {
                 const ids = childItems.value
@@ -85,7 +83,7 @@ export function useProviderParent<ItemData = unknown, ParentData = unknown>(
                     .join(",");
                 const parent = unrefElement(rootRef);
                 const children = parent.querySelectorAll(ids);
-                const sortedIds = Array.from(children).map((el: any) =>
+                const sortedIds = Array.from(children).map((el) =>
                     el.getAttribute("data-id").replace(`${key}-`, ""),
                 );
 

--- a/packages/oruga/src/composables/useParentProvider.ts
+++ b/packages/oruga/src/composables/useParentProvider.ts
@@ -62,6 +62,7 @@ export function useProviderParent<ItemData = unknown, ParentData = unknown>(
 
     const childItems = ref<ProviderItem<ItemData>[]>([]);
     const sequence = ref(1);
+
     /**
      * When items are added/removed sort them according to their position
      */


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #885
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- add `UnwrapNestedRefs` type wrapper for `childItems` in `useProviderParent` composable