### PR TITLE
fix(table): fix filtering when table is not sorted

### DIFF
--- a/packages/oruga/src/components/table/Table.vue
+++ b/packages/oruga/src/components/table/Table.vue
@@ -947,7 +947,10 @@ function handleFiltersChange(value: Record<string, string>): void {
             dataTotal.value = tableRows.value.length;
         }
         if (!props.backendSorting) {
-            if (Object.keys(currentSortColumn.value).length > 0) {
+            if (
+                currentSortColumn.value &&
+                Object.keys(currentSortColumn.value).length > 0
+            ) {
                 doSortSingleColumn(currentSortColumn.value);
             }
         }


### PR DESCRIPTION
## Proposed Changes

Fixes table filtering when table is not yet sorted
`currentSortColumn` is undefined when the table is not sorted ( no `defaultSort` prop defined) and the property is accessed in `handleFilter` function throwing an error
Adding a safe guard in the function
