### PR TITLE
fix: always validate programmatic date updates for picker components

### DIFF
--- a/packages/oruga/src/components/utils/PickerWrapper.vue
+++ b/packages/oruga/src/components/utils/PickerWrapper.vue
@@ -123,9 +123,9 @@ watch(
     () => {
         // toggle picker if not stay open
         if (!props.stayOpen) togglePicker(false);
-        // check validation if native
-        if (isMobileNative.value && !isValid.value) checkHtml5Validity();
+        if (!isValid.value) checkHtml5Validity();
     },
+    { flush: "post" },
 );
 
 const isActive = usePropBinding<boolean>("active", props, emits, {


### PR DESCRIPTION
HTML constraint validation can apply even if we're not using the native date picker, so I don't see a strong reason to skip `checkHtml5Validity()`.

## Proposed Changes

Previously, date and time pickers would only try to clear their constraint validation messages on direct user updates or `blur` events when in desktop mode, not on programmatic updates. In the video below, note that I have to blur the field before the validation message fixes itself:

[before.webm](https://github.com/oruga-ui/oruga/assets/2198455/dc545cc8-e21e-4e3f-8c48-9f2c9c1251fc)

This is inconsistent with the behavior of other inputs, which will clear their validation messages even if not updated due to direct user input.

[after.webm](https://github.com/oruga-ui/oruga/assets/2198455/9a65d1b3-15af-4553-ae0f-699a894ebefe)

Here's the code I used to demonstrate the issue:

```vue
<script setup lang="ts">
import { OButton, ODatepicker } from '@oruga-ui/oruga-next';
import { ref } from 'vue';

const date = ref<Date | undefined>(undefined);

</script>

<template>
  <main>
    <OField label="Date">
      <ODatepicker v-model="date" required />
    </OField>
    <OField>
      <OButton type="button" @click="date = new Date()">Set Date</OButton>
    </OField>
  </main>
</template>
```