### PR TITLE
feat(inputs): detect constraint validation attribute changes

### DIFF
--- a/packages/oruga/src/composables/useInputHandler.ts
+++ b/packages/oruga/src/composables/useInputHandler.ts
@@ -138,7 +138,7 @@ export function useInputHandler(
      * If validation fail, send 'danger' type,
      * and error message to parent if it's a Field.
      */
-    function checkHtml5Validity(): boolean {
+    function checkHtml5Validity(): void {
         if (!props.useHtml5Validation) return;
 
         if (!element.value) return;
@@ -149,8 +149,6 @@ export function useInputHandler(
             setInvalid();
             isValid.value = false;
         }
-
-        return isValid.value;
     }
 
     function setInvalid(): void {

--- a/packages/oruga/src/composables/useInputHandler.ts
+++ b/packages/oruga/src/composables/useInputHandler.ts
@@ -74,6 +74,9 @@ export function useInputHandler(
     // inject parent field component if used inside one
     const { parentField } = injectField();
 
+    /// Allows access to the native element in cases where it might be missing,
+    /// e.g. because the component hasn't been mounted yet or has been suspended
+    /// by a <KeepAlive>
     const maybeElement = computed<ValidatableFormElement | undefined>(() => {
         const el = unrefElement<Component | HTMLElement>(inputRef);
         if (!el) {
@@ -95,6 +98,8 @@ export function useInputHandler(
         return inputs as ValidatableFormElement;
     });
 
+    /// Should be used for most accesses to the native element; we generally
+    /// expect it to be present, especially in event handlers.
     const element = computed(() => {
         const el = maybeElement.value;
         if (!el) {

--- a/packages/oruga/src/composables/useInputHandler.ts
+++ b/packages/oruga/src/composables/useInputHandler.ts
@@ -11,6 +11,7 @@ import { injectField } from "@/components/field/fieldInjection";
 import { unrefElement } from "./unrefElement";
 import { getOption } from "@/utils/config";
 import { isSSR } from "@/utils/ssr";
+import { isDefined } from "@/utils/helpers";
 
 // This should cover all types of HTML elements that have properties related to
 // HTML constraint validation, e.g. .form and .validity.
@@ -263,7 +264,7 @@ export function useInputHandler(
                     ancestorMutationObserver.disconnect();
                 }
 
-                if (el == undefined || valid || !useValidation) {
+                if (!isDefined(el) || valid || !useValidation) {
                     return;
                 }
 

--- a/packages/oruga/src/composables/useInputHandler.ts
+++ b/packages/oruga/src/composables/useInputHandler.ts
@@ -240,7 +240,6 @@ export function useInputHandler(
             if (!isValid.value) checkHtml5Validity();
         };
         let validationAttributeObserver: MutationObserver | null = null;
-        let ancestorMutationObserver: MutationObserver | null = null;
         watch(
             [maybeElement, isValid, () => props.useHtml5Validation],
             (data) => {
@@ -256,12 +255,6 @@ export function useInputHandler(
                         onAttributeChange();
                     }
                     validationAttributeObserver.disconnect();
-                }
-                if (ancestorMutationObserver != null) {
-                    if (ancestorMutationObserver.takeRecords().length > 0) {
-                        onAttributeChange();
-                    }
-                    ancestorMutationObserver.disconnect();
                 }
 
                 if (!isDefined(el) || valid || !useValidation) {
@@ -285,12 +278,7 @@ export function useInputHandler(
                 while ((ancestor = ancestor.parentNode)) {
                     // Form controls can be disabled by their ancestor fieldsets.
                     if (ancestor instanceof HTMLFieldSetElement) {
-                        if (ancestorMutationObserver == null) {
-                            ancestorMutationObserver = new MutationObserver(
-                                onAttributeChange,
-                            );
-                        }
-                        ancestorMutationObserver.observe(ancestor, {
+                        validationAttributeObserver.observe(ancestor, {
                             attributeFilter: ["disabled"],
                         });
                     }


### PR DESCRIPTION
When attributes related to HTML constraint validation change on an input, they may change or even remove the validation error on the input. Ideally, we'd reflect the change of validation error in the enclosing field.

## Proposed Changes

Changes to the following attributes on an invalid form element should trigger a call to `checkHtml5Validity`:

- `required`
- `pattern`
- `maxlength`
- `minlength`
- `max`
- `min`
- `step`

Additionally, changes to the `disabled` attribute on the input or any ancestor `<fieldset>` should trigger a call to `checkHtml5Validity`.

## Sample

```vue
<script setup lang="ts">
import { OCheckbox, OInput } from '@oruga-ui/oruga-next';
import { ref } from 'vue';

const val = ref("");
const required = ref(true);
const disabled = ref(false);
const groupDisabled = ref(false);
</script>

<template>
  <main>
    <OField label="Value">
      <fieldset :disabled="groupDisabled">
        <OInput v-model="val" :required :disabled />
      </fieldset>
    </OField>
    <OField>
      <OCheckbox v-model="required">Required</OCheckbox>
    </OField>
    <OField>
      <OCheckbox v-model="disabled">Disabled (directly)</OCheckbox>
    </OField>
    <OField>
      <OCheckbox v-model="groupDisabled">Disabled (group)</OCheckbox>
    </OField>
  </main>
</template>
```

### Before

[before.webm](https://github.com/oruga-ui/oruga/assets/2198455/151beef3-12a4-4d47-8a0d-795cda06541a)

### After

[after.webm](https://github.com/oruga-ui/oruga/assets/2198455/d2e78568-34b9-4f12-b645-4f92f22abbbb)
