### PR TITLE
fix(icon): adjust `component` prop type

### DIFF
--- a/packages/oruga/src/components/icon/Icon.vue
+++ b/packages/oruga/src/components/icon/Icon.vue
@@ -5,7 +5,7 @@ import { getOption } from "@/utils/config";
 import getIcons from "@/utils/icons";
 import { defineClasses } from "@/composables";
 
-import type { ComponentClass } from "@/types";
+import type { ComponentClass, DynamicComponent } from "@/types";
 
 /**
  * Icons take an important role of any application
@@ -23,7 +23,7 @@ const props = defineProps({
     override: { type: Boolean, default: undefined },
     /** Icon component name */
     component: {
-        type: String,
+        type: [String, Object, Function] as PropType<DynamicComponent>,
         default: () => getOption("iconComponent"),
     },
     /**


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #1027
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- change type of `component` prop to accept component objects and component constructor functions
