### PR TITLE
refactor(slider): rename `customFormatter` prop to `formatter` prop

### DIFF
--- a/packages/oruga/src/components/slider/Slider.vue
+++ b/packages/oruga/src/components/slider/Slider.vue
@@ -39,7 +39,7 @@ const props = withDefaults(defineProps<SelectProps<IsRange>>(), {
     rounded: () => getOption("slider.rounded", false),
     disabled: false,
     lazy: false,
-    customFormatter: undefined,
+    formatter: undefined,
     biggerSliderFocus: false,
     indicator: false,
     format: () => getOption("slider.format", "raw"),

--- a/packages/oruga/src/components/slider/SliderThumb.vue
+++ b/packages/oruga/src/components/slider/SliderThumb.vue
@@ -88,8 +88,8 @@ const currentPosition = computed(
 const wrapperStyle = computed(() => ({ left: currentPosition.value }));
 
 const formattedValue = computed(() => {
-    if (typeof slider.value.customFormatter !== "undefined")
-        return slider.value.customFormatter(props.modelValue);
+    if (typeof slider.value.formatter !== "undefined")
+        return slider.value.formatter(props.modelValue);
 
     if (slider.value.format === "percent")
         return new Intl.NumberFormat(slider.value.locale, {

--- a/packages/oruga/src/components/slider/examples/base.vue
+++ b/packages/oruga/src/components/slider/examples/base.vue
@@ -29,9 +29,7 @@ const sliderType = computed(() => {
         </o-field>
 
         <o-field label="Custom tooltip label">
-            <o-slider
-                :model-value="30"
-                :custom-formatter="(val) => val + '%'" />
+            <o-slider :model-value="30" :formatter="(val) => val + '%'" />
         </o-field>
 
         <o-field label="Rounded thumb">

--- a/packages/oruga/src/components/slider/props.ts
+++ b/packages/oruga/src/components/slider/props.ts
@@ -41,7 +41,7 @@ export type SelectProps<IsRange extends boolean> = {
     /** Update v-model only when dragging is finished */
     lazy?: boolean;
     /** Function to format the tooltip label for display */
-    customFormatter?: Function;
+    formatter?: (value: number) => string;
     /** Increases slider size on focus */
     biggerSliderFocus?: boolean;
     /** Show indicators */

--- a/packages/oruga/src/components/tabs/Tabs.vue
+++ b/packages/oruga/src/components/tabs/Tabs.vue
@@ -402,7 +402,6 @@ function itemHeaderClasses(
             -->
             <slot name="start" />
 
-            <!--  add keydown evtnt handler to navigate tabs - vortrag frontend circle -->
             <div
                 v-for="childItem in items"
                 v-show="childItem.visible"
@@ -453,6 +452,7 @@ function itemHeaderClasses(
                     </span>
                 </component>
             </div>
+
             <!--
                 @slot Additional slot after tabs
             -->

--- a/packages/oruga/src/components/tabs/Tabs.vue
+++ b/packages/oruga/src/components/tabs/Tabs.vue
@@ -401,6 +401,8 @@ function itemHeaderClasses(
                 @slot Additional slot before tabs
             -->
             <slot name="start" />
+
+            <!--  add keydown evtnt handler to navigate tabs - vortrag frontend circle -->
             <div
                 v-for="childItem in items"
                 v-show="childItem.visible"


### PR DESCRIPTION
## Proposed Changes

- rename the slider `customFormatter` prop to `formatter` prop to make it consistent with other components.