### PR TITLE
fix(1038): add `vue-component-type-helpers` as dependency

### DIFF
--- a/packages/oruga/package.json
+++ b/packages/oruga/package.json
@@ -69,6 +69,9 @@
   "peerDependencies": {
     "vue": "^3.0.0"
   },
+  "dependencies": {
+    "vue-component-type-helpers": "^2.1.6"
+  },
   "devDependencies": {
     "@babel/core": "7.25.2",
     "@babel/preset-env": "7.25.4",
@@ -105,7 +108,6 @@
     "vitest": "^2.1.1",
     "vue": "^3.5.6",
     "vue-component-meta": "^2.1.6",
-    "vue-component-type-helpers": "^2.1.6",
     "vue-tsc": "^2.1.6"
   }
 }

--- a/packages/oruga/vite.config.js
+++ b/packages/oruga/vite.config.js
@@ -116,7 +116,14 @@ export default defineConfig(({ mode }) => ({
             ],
         },
     },
-    plugins: [tsconfigPaths(), vue(), dts({ outDir: "./dist/types" })],
+    plugins: [
+        tsconfigPaths(),
+        vue(),
+        dts({
+            outDir: "./dist/types",
+            bundledPackages: ["vue-component-type-helpers"],
+        }),
+    ],
     test: {
         setupFiles: [resolve("./src/__tests__/vitest.setup.ts")],
         environment: "jsdom",


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Part of #1038
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- add `vue-component-type-helpers` as dependency
- added `vue-component-type-helpers` as vite-plugin-dts `bundledPackages` entry, this does not currently work as intended
