### PR TITLE
fix(a11y): remove unnecessary `aria-hidden="true"` on  overlays

### DIFF
--- a/packages/oruga/src/components/loading/Loading.vue
+++ b/packages/oruga/src/components/loading/Loading.vue
@@ -199,7 +199,6 @@ defineExpose({ close, promise: props.promise });
             <div
                 :class="overlayClasses"
                 :tabindex="-1"
-                aria-hidden="true"
                 @click="cancel('outside')" />
             <!-- 
                 @slot Override icon and label

--- a/packages/oruga/src/components/loading/tests/__snapshots__/loading.test.ts.snap
+++ b/packages/oruga/src/components/loading/tests/__snapshots__/loading.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`OLoading tests > render correctly 1`] = `
 "<transition-stub name="fade" appear="false" persisted="false" css="true">
   <div data-oruga="loading" role="dialog" class="o-load o-load--fullpage">
-    <div class="o-load__overlay" tabindex="-1" aria-hidden="true"></div>
+    <div class="o-load__overlay" tabindex="-1"></div>
     <!-- 
                 @slot Override icon and label
                 @binding {close} close - function to close the component

--- a/packages/oruga/src/components/modal/Modal.vue
+++ b/packages/oruga/src/components/modal/Modal.vue
@@ -377,7 +377,6 @@ defineExpose({ close, promise: props.promise });
                     v-if="overlay"
                     :class="overlayClasses"
                     tabindex="-1"
-                    aria-hidden="true"
                     @click="clickedOutside" />
 
                 <div

--- a/packages/oruga/src/components/modal/tests/__snapshots__/modal.test.ts.snap
+++ b/packages/oruga/src/components/modal/tests/__snapshots__/modal.test.ts.snap
@@ -4,7 +4,7 @@ exports[`OModal tests > render correctly 1`] = `
 "<!--teleport start-->
 <transition-stub name="zoom-out" appear="false" persisted="true" css="true">
   <div data-oruga="modal" class="o-modal" tabindex="-1" aria-modal="false" style="display: none;">
-    <div class="o-modal__overlay" tabindex="-1" aria-hidden="true"></div>
+    <div class="o-modal__overlay" tabindex="-1"></div>
     <div class="o-modal__content" style="max-width: 960px;">
       <!-- injected component for programmatic usage -->
       <!--

--- a/packages/oruga/src/components/sidebar/Sidebar.vue
+++ b/packages/oruga/src/components/sidebar/Sidebar.vue
@@ -501,7 +501,6 @@ defineExpose({ close, promise: props.promise });
                 v-if="overlay && isActive"
                 :class="overlayClasses"
                 :tabindex="-1"
-                aria-hidden="true"
                 @click="clickedOutside" />
 
             <transition


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #1039
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- remove unnecessary `aria-hidden="true"` on modal, sidebar and loading overlays
