### PR TITLE
docs: add `theme-light` specification

### DIFF
--- a/packages/docs/.vitepress/theme/components/ThemeSelector.vue
+++ b/packages/docs/.vitepress/theme/components/ThemeSelector.vue
@@ -1,8 +1,8 @@
-<script setup>
+<script setup lang="ts">
 // Import theme definitions
 import themes from "../../themes.json";
 
-const selectedTheme = defineModel("theme");
+const selectedTheme = defineModel<any>("theme");
 
 selectedTheme.value = loadTheme();
 
@@ -15,13 +15,14 @@ function loadTheme() {
             if (themeConfig && typeof themeConfig === "object")
                 return themeConfig;
         } catch (e) {
+            console.log(e);
             return themes[1];
         }
     }
     return themes[1];
 }
 
-function onThemeChange(theme) {
+function onThemeChange(theme: unknown): void {
     selectedTheme.value = theme;
     localStorage.setItem("oruga-ui.com:theme", JSON.stringify(theme));
     location.reload();
@@ -32,20 +33,15 @@ function onThemeChange(theme) {
     <o-dropdown
         :model-value="selectedTheme"
         root-class="theme-selector"
-        aria-role="list"
         @change="onThemeChange">
         <template #trigger="{ active }">
             <span role="button">
-                Theme ➜ {{ selectedTheme.label }}
+                Theme ➜ {{ selectedTheme?.label }}
                 <o-icon :icon="active ? 'caret-up' : 'caret-down'" />
             </span>
         </template>
 
-        <o-dropdown-item
-            v-for="item in themes"
-            :key="item.key"
-            :value="item"
-            aria-role="listitem">
+        <o-dropdown-item v-for="item in themes" :key="item.key" :value="item">
             {{ item.label }}
         </o-dropdown-item>
     </o-dropdown>

--- a/packages/docs/.vitepress/theme/layout/Layout.vue
+++ b/packages/docs/.vitepress/theme/layout/Layout.vue
@@ -10,7 +10,7 @@ const theme = ref({ key: undefined });
 </script>
 
 <template>
-    <Layout :class="theme.key">
+    <Layout :class="theme.key" data-theme="light">
         <template #nav-bar-content-before>
             <ClientOnly>
                 <ThemeSelector v-if="hasSidebar" v-model:theme="theme" />


### PR DESCRIPTION
## Proposed Changes

- The bulma theme has an automatic detection of the environment color specification, but vitpress and the other themes don't. So we force the bulma theme to use light mode.