### PR TITLE
fix(programmatic): solve wrong `events` prop type

### DIFF
--- a/packages/oruga/src/components/modal/props.ts
+++ b/packages/oruga/src/components/modal/props.ts
@@ -56,7 +56,7 @@ export type ModalProps<C extends Component> = {
     teleport?: boolean | string | object;
     /**
      * Component to be injected.
-     * Close the programmatic component within the component by emitting a 'close' event — `$emit('close')`
+     * Close the component by emitting a 'close' event — `$emit('close')`
      */
     component?: C;
     /** Props to be binded to the injected component */

--- a/packages/oruga/src/components/modal/props.ts
+++ b/packages/oruga/src/components/modal/props.ts
@@ -1,6 +1,6 @@
 import type { Component } from "vue";
-import type { ComponentClass } from "@/types";
-import type { ComponentEmit, ComponentProps } from "vue-component-type-helpers";
+import type { ComponentClass, ComponentEmits } from "@/types";
+import type { ComponentProps } from "vue-component-type-helpers";
 
 export type ModalProps<C extends Component> = {
     /** Override existing theme classes completely */
@@ -55,14 +55,14 @@ export type ModalProps<C extends Component> = {
      */
     teleport?: boolean | string | object;
     /**
-     * Component to be injected, used to open a component modal programmatically.
-     * Close modal within the component by emitting a 'close' event — emits('close')
+     * Component to be injected.
+     * Close the programmatic component within the component by emitting a 'close' event — `$emit('close')`
      */
     component?: C;
     /** Props to be binded to the injected component */
     props?: ComponentProps<C>;
     /** Events to be binded to the injected component */
-    events?: ComponentEmit<C>;
+    events?: ComponentEmits<C>;
 } & ModalClasses;
 
 // class props (will not be displayed in the docs)

--- a/packages/oruga/src/components/notification/props.ts
+++ b/packages/oruga/src/components/notification/props.ts
@@ -104,7 +104,7 @@ export type NotificationNoticeProps<C extends Component> = {
     queue?: boolean;
     /**
      * Component to be injected.
-     * Close notification within the component by emitting a 'close' event — $emit('close').
+     * Close the component by emitting a 'close' event — `$emit('close')`
      */
     component?: Component;
     /** Props to be binded to the injected component */

--- a/packages/oruga/src/components/notification/props.ts
+++ b/packages/oruga/src/components/notification/props.ts
@@ -1,6 +1,6 @@
 import type { Component } from "vue";
-import type { ComponentClass } from "@/types";
-import type { ComponentEmit, ComponentProps } from "vue-component-type-helpers";
+import type { ComponentClass, ComponentEmits } from "@/types";
+import type { ComponentProps } from "vue-component-type-helpers";
 
 export type NotificationProps = {
     /** Override existing theme classes completely */
@@ -110,7 +110,7 @@ export type NotificationNoticeProps<C extends Component> = {
     /** Props to be binded to the injected component */
     props?: ComponentProps<C>;
     /** Events to be binded to the injected component */
-    events?: ComponentEmit<C>;
+    events?: ComponentEmits<C>;
 } & NotificationNoticeClasses;
 
 // class props (will not be displayed in the docs)

--- a/packages/oruga/src/components/sidebar/props.ts
+++ b/packages/oruga/src/components/sidebar/props.ts
@@ -51,8 +51,8 @@ export type SidebarProps<C extends Component> = {
      */
     teleport?: boolean | string | object;
     /**
-     * Component to be injected, used to open a component sidebar programmatically.
-     * Close sidebar within the component by emitting a 'close' event — emits('close')
+     * Component to be injected.
+     * Close the component by emitting a 'close' event — `$emit('close')`
      */
     component?: C;
     /** Props to be binded to the injected component */

--- a/packages/oruga/src/components/sidebar/props.ts
+++ b/packages/oruga/src/components/sidebar/props.ts
@@ -1,6 +1,6 @@
 import type { Component } from "vue";
-import type { ComponentClass } from "@/types";
-import type { ComponentEmit, ComponentProps } from "vue-component-type-helpers";
+import type { ComponentClass, ComponentEmits } from "@/types";
+import type { ComponentProps } from "vue-component-type-helpers";
 
 export type SidebarProps<C extends Component> = {
     /** Override existing theme classes completely */
@@ -58,7 +58,7 @@ export type SidebarProps<C extends Component> = {
     /** Props to be binded to the injected component */
     props?: ComponentProps<C>;
     /** Events to be binded to the injected component */
-    events?: ComponentEmit<C>;
+    events?: ComponentEmits<C>;
 } & SidebarClasses;
 
 // class props (will not be displayed in the docs)

--- a/packages/oruga/src/components/steps/props.ts
+++ b/packages/oruga/src/components/steps/props.ts
@@ -1,6 +1,11 @@
 import type { Component } from "vue";
-import type { ComponentClass, DynamicComponent, OptionsProp } from "@/types";
-import type { ComponentEmit, ComponentProps } from "vue-component-type-helpers";
+import type {
+    ComponentClass,
+    ComponentEmits,
+    DynamicComponent,
+    OptionsProp,
+} from "@/types";
+import type { ComponentProps } from "vue-component-type-helpers";
 
 export type StepsProps<T> = {
     /** Override existing theme classes completely */
@@ -142,7 +147,7 @@ export type StepItemProps<T, C extends Component> = {
     /** Props to be binded to the injected component */
     props?: ComponentProps<C>;
     /** Events to be binded to the injected component */
-    events?: ComponentEmit<C>;
+    events?: ComponentEmits<C>;
 } & StepItemClasses;
 
 // class props (will not be displayed in the docs)

--- a/packages/oruga/src/components/tabs/props.ts
+++ b/packages/oruga/src/components/tabs/props.ts
@@ -1,6 +1,11 @@
 import type { Component } from "vue";
-import type { ComponentClass, DynamicComponent, OptionsProp } from "@/types";
-import type { ComponentEmit, ComponentProps } from "vue-component-type-helpers";
+import type {
+    ComponentClass,
+    ComponentEmits,
+    DynamicComponent,
+    OptionsProp,
+} from "@/types";
+import type { ComponentProps } from "vue-component-type-helpers";
 
 export type TabsProps<T> = {
     /** Override existing theme classes completely */
@@ -106,7 +111,7 @@ export type TabItemProps<T, C extends Component> = {
     /** Props to be binded to the injected component */
     props?: ComponentProps<C>;
     /** Events to be binded to the injected component */
-    events?: ComponentEmit<C>;
+    events?: ComponentEmits<C>;
 } & TabItemClasses;
 
 // class props (will not be displayed in the docs)

--- a/packages/oruga/src/types/utils.ts
+++ b/packages/oruga/src/types/utils.ts
@@ -18,11 +18,11 @@ export type PropBind =
 /** Vue native dynamic component 'is' property value type */
 export type DynamicComponent = string | object | CallableFunction | Component;
 
-/** Define a property as  required */
+/** Define a property as required */
 export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 
 /**
- * Extract all properties of an object which starts with an `on` prefix.
+ * Extract all properties of an object which starts with a `on` prefix.
  * It also cuts the `on` prefix and lowercase the first char.
  */
 type ComponentEmitsByProps<T> = {
@@ -34,7 +34,7 @@ type ComponentEmitsByProps<T> = {
 };
 
 /**
- * Custom ComponentEmits helper which defines the emits of an component as object.
+ * Custom type helper which extracts the `$emits` type of an component as object.
  *
  * Because the `ComponentEmit` from "vue-component-type-helpers" does not export the emits as an object but as:
  * `((event: "close", ...args: any[]) => void) | undefined`
@@ -46,7 +46,7 @@ type TypeOfKey<T, K extends string> = K extends keyof T ? T[K] : unknown;
 
 /**
  * Extracts the type of a deep property `K` within an object `T`.
- * `K` can be defined as property path with `.` seperator.
+ * Property `K` can be defined as a property path with `.` seperator.
  */
 export type DeepType<T, K> = T extends object
     ? K extends string

--- a/packages/oruga/src/types/utils.ts
+++ b/packages/oruga/src/types/utils.ts
@@ -34,9 +34,9 @@ type ComponentEmitsByProps<T> = {
 };
 
 /**
- * Custom ComponentEmits helper which defines the emits as object.
+ * Custom ComponentEmits helper which defines the emits of an component as object.
  *
- * Because the `ComponentEmits` from "vue-component-type-helpers" does not export the emits as an object but as:
+ * Because the `ComponentEmit` from "vue-component-type-helpers" does not export the emits as an object but as:
  * `((event: "close", ...args: any[]) => void) | undefined`
  */
 export type ComponentEmits<C> = ComponentEmitsByProps<ComponentProps<C>>;

--- a/packages/oruga/src/types/utils.ts
+++ b/packages/oruga/src/types/utils.ts
@@ -1,6 +1,5 @@
 import type { Component } from "vue";
-
-export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+import type { ComponentProps } from "vue-component-type-helpers";
 
 export type ClassBind = {
     [x: string]: boolean;
@@ -19,8 +18,36 @@ export type PropBind =
 /** Vue native dynamic component 'is' property value type */
 export type DynamicComponent = string | object | CallableFunction | Component;
 
+/** Define a property as  required */
+export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+
+/**
+ * Extract all properties of an object which starts with an `on` prefix.
+ * It also cuts the `on` prefix and lowercase the first char.
+ */
+type ComponentEmitsByProps<T> = {
+    [K in keyof T as K extends `on${infer S}`
+        ? S extends `${infer First}${infer Rest}`
+            ? `${Lowercase<First>}${Rest}`
+            : S
+        : never]: T[K];
+};
+
+/**
+ * Custom ComponentEmits helper which defines the emits as object.
+ *
+ * Because the `ComponentEmits` from "vue-component-type-helpers" does not export the emits as an object but as:
+ * `((event: "close", ...args: any[]) => void) | undefined`
+ */
+export type ComponentEmits<C> = ComponentEmitsByProps<ComponentProps<C>>;
+
+/** Extracts the type of property `K` in object `T`. */
 type TypeOfKey<T, K extends string> = K extends keyof T ? T[K] : unknown;
 
+/**
+ * Extracts the type of a deep property `K` within an object `T`.
+ * `K` can be defined as property path with `.` seperator.
+ */
 export type DeepType<T, K> = T extends object
     ? K extends string
         ? K extends `${infer F}.${infer R}`


### PR DESCRIPTION
## Proposed Changes

- create a custom `ComponentEmits` helper which defines the emits of an component as object. Because the `ComponentEmit` from "vue-component-type-helpers" does not export the emits as an object but as: `((event: "close", ...args: any[]) => void) | undefined`