### PR TITLE
fix(table): prevent table paginate unsafe property inheritance

### DIFF
--- a/packages/oruga/src/components/table/Table.vue
+++ b/packages/oruga/src/components/table/Table.vue
@@ -487,7 +487,10 @@ const hasCustomSubheadings = computed(() => {
 function hasCustomFooterSlot(): boolean {
     if (!slots.footer) return false;
 
-    const footer = slots.footer();
+    const footer = slots.footer({
+        columnCount: columnCount.value,
+        rowCount: visibleRows.value.length,
+    });
     if (footer.length > 1) return true;
 
     const tag = footer[0]["type"];
@@ -1365,7 +1368,9 @@ defineExpose({ rows: tableData, sort: sortByField });
                                     :props="{ column, index }" />
                             </template>
                             <template v-else>
-                                {{ column.subheading }}
+                                <slot name="subheading">
+                                    {{ column.subheading }}
+                                </slot>
                             </template>
                         </th>
                         <!-- checkable column right -->

--- a/packages/oruga/src/components/table/TablePagination.vue
+++ b/packages/oruga/src/components/table/TablePagination.vue
@@ -9,6 +9,7 @@ defineOptions({
     isOruga: true,
     name: "OTablePagination",
     configField: "table",
+    inheritAttrs: false,
 });
 
 defineProps({


### PR DESCRIPTION

## Proposed Changes

- add inheritance `inheritAttrs: false` to PaginationTable
- fix some minor Table type issues
- add a globale `subheading` slot to the Table component
