### PR TITLE
fix(checkbox|radio|switch): correct formula issues with label slot

### DIFF
--- a/packages/oruga/src/components/checkbox/Checkbox.vue
+++ b/packages/oruga/src/components/checkbox/Checkbox.vue
@@ -82,7 +82,7 @@ const { parentField } = injectField();
 
 // set field labelId or create a unique label id if a label is given
 const labelId =
-    !!parentField.value || !!props.label || !!useSlots().label
+    !!parentField.value || !!props.label || !!useSlots().default
         ? parentField.value?.labelId || useId()
         : undefined;
 

--- a/packages/oruga/src/components/radio/Radio.vue
+++ b/packages/oruga/src/components/radio/Radio.vue
@@ -78,7 +78,7 @@ const { parentField } = injectField();
 
 // set field labelId or create a unique label id if a label is given
 const labelId =
-    !!parentField.value || !!props.label || !!useSlots().label
+    !!parentField.value || !!props.label || !!useSlots().default
         ? parentField.value?.labelId || useId()
         : undefined;
 

--- a/packages/oruga/src/components/switch/Switch.vue
+++ b/packages/oruga/src/components/switch/Switch.vue
@@ -83,7 +83,7 @@ const { parentField } = injectField();
 
 // set field labelId or create a unique label id if a label is given
 const labelId =
-    !!parentField.value || !!props.label || !!useSlots().label
+    !!parentField.value || !!props.label || !!useSlots().default
         ? parentField.value?.labelId || useId()
         : undefined;
 


### PR DESCRIPTION
## Proposed Changes

- Corrected a formula calculation: the labelId now correctly checks the default slot instead of a non-existing label slot.