### PR TITLE
fix(table): solve a table column ordering problem

### DIFF
--- a/packages/oruga/src/components/table/TableColumn.vue
+++ b/packages/oruga/src/components/table/TableColumn.vue
@@ -123,7 +123,7 @@ const filters = {} as Record<string, string>;
 </script>
 
 <template>
-    <span data-oruga="table-column" :data-id="item.identifier">
+    <span data-oruga="table-column" :data-id="`table-${item.identifier}`">
         {{ label }}
 
         <!--

--- a/packages/oruga/src/composables/useParentProvider.ts
+++ b/packages/oruga/src/composables/useParentProvider.ts
@@ -74,10 +74,10 @@ export function useProviderParent<ItemData = unknown, ParentData = unknown>(
                 .map((item) => `[data-id="${key}-${item.identifier}"]`)
                 .join(",");
 
-            // query all child items
+            // query all child items in the order of the DOM appearance
             const children = parent.querySelectorAll(ids);
 
-            // create a list of ids ordered after the elements in template
+            // create a list of ids ordered after the elements in DOM
             const sortedIds = Array.from(children).map((el) =>
                 el.getAttribute("data-id")?.replace(`${key}-`, ""),
             );


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #1160
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Update the `data-id` property of the root template of the TableColumn component to follow the convention that allows proper columns to be sorted by template order by the `useParentProvider` composable.