### PR TITLE
fix(tabs|steps): replace falsly check with nullish check for default `value` prop

### DIFF
--- a/packages/oruga/src/components/steps/StepItem.vue
+++ b/packages/oruga/src/components/steps/StepItem.vue
@@ -43,7 +43,7 @@ const emits = defineEmits<{
     deactivate: [];
 }>();
 
-const itemValue = props.value || useId();
+const itemValue = props.value ?? useId();
 
 const slots = useSlots();
 
@@ -190,12 +190,12 @@ const panelClasses = defineClasses(["stepPanelClass", "o-steps__panel"]);
                 @binding {boolean} active - if item is shown 
             -->
             <slot :active="isActive && visible">
-                    <!-- injected component -->
-                    <component
-                        :is="component"
-                        v-if="component"
-                        v-bind="$props.props"
-                        v-on="$props.events || {}" />
+                <!-- injected component -->
+                <component
+                    :is="component"
+                    v-if="component"
+                    v-bind="$props.props"
+                    v-on="$props.events || {}" />
 
                 <!-- default content prop -->
                 <template v-else>{{ content }}</template>

--- a/packages/oruga/src/components/tabs/TabItem.vue
+++ b/packages/oruga/src/components/tabs/TabItem.vue
@@ -39,7 +39,7 @@ const emits = defineEmits<{
     deactivate: [];
 }>();
 
-const itemValue = props.value || useId();
+const itemValue = props.value ?? useId();
 
 const slots = useSlots();
 

--- a/packages/oruga/src/components/tabs/tests/tabs.test.ts
+++ b/packages/oruga/src/components/tabs/tests/tabs.test.ts
@@ -324,12 +324,12 @@ describe("OTabs tests", () => {
         describe("handle options props correctly", () => {
             test("handle options as primitves correctly", async () => {
                 const options: OptionsProp = [
-                    "Flint",
-                    "Silver",
-                    "Vane",
                     0,
                     1,
                     2,
+                    "Flint",
+                    "Silver",
+                    "Vane",
                 ];
 
                 const wrapper = mount(OTabs, { props: { options } });
@@ -346,6 +346,10 @@ describe("OTabs tests", () => {
                 navElements.forEach((el, idx) => {
                     expect(el.text()).toBe(String(options[idx]));
                 });
+
+                expect(wrapper.emitted("update:modelValue")).toStrictEqual([
+                    ["0"],
+                ]);
             });
 
             test("handle options as object correctly", async () => {


### PR DESCRIPTION
Fixes #1159
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- The bug only occurs if the `value` prop represents a falsly value, aka `null`, `NaN`, `0`, `""` or `undefined`. This is due to the line `props.value || useId()`. I will update this to `props.value ?? useId()` so that now the `value` will only be a unique id if the value is nullish, aka `null` or `undefined`. 
