### PR TITLE
refacor(programmatic): add internal `container` property for programmatic components

### DIFF
--- a/packages/oruga/src/components/loading/props.ts
+++ b/packages/oruga/src/components/loading/props.ts
@@ -30,6 +30,11 @@ export type LoadingProps = {
     scroll?: "keep" | "clip";
     /** Role attribute to be passed to the div wrapper for better accessibility */
     role?: string;
+    /**
+     * DOM container element for programmatic usage.
+     * @ignore internal property
+     */
+    container: HTMLElement;
 } & LoadingClasses;
 
 // class props (will not be displayed in the docs)

--- a/packages/oruga/src/components/loading/props.ts
+++ b/packages/oruga/src/components/loading/props.ts
@@ -34,7 +34,7 @@ export type LoadingProps = {
      * DOM container element for programmatic usage.
      * @ignore internal property
      */
-    container: HTMLElement;
+    container?: HTMLElement;
 } & LoadingClasses;
 
 // class props (will not be displayed in the docs)

--- a/packages/oruga/src/components/modal/props.ts
+++ b/packages/oruga/src/components/modal/props.ts
@@ -55,6 +55,11 @@ export type ModalProps<C extends Component = Component> = {
      */
     teleport?: boolean | string | object;
     /**
+     * DOM container element for programmatic usage.
+     * @ignore internal property
+     */
+    container: HTMLElement;
+    /**
      * Component to be injected.
      * Close the component by emitting a 'close' event — `$emit('close')`
      */

--- a/packages/oruga/src/components/modal/props.ts
+++ b/packages/oruga/src/components/modal/props.ts
@@ -58,7 +58,7 @@ export type ModalProps<C extends Component = Component> = {
      * DOM container element for programmatic usage.
      * @ignore internal property
      */
-    container: HTMLElement;
+    container?: HTMLElement;
     /**
      * Component to be injected.
      * Close the component by emitting a 'close' event — `$emit('close')`

--- a/packages/oruga/src/components/sidebar/props.ts
+++ b/packages/oruga/src/components/sidebar/props.ts
@@ -54,7 +54,7 @@ export type SidebarProps<C extends Component = Component> = {
      * DOM container element for programmatic usage.
      * @ignore internal property
      */
-    container: HTMLElement;
+    container?: HTMLElement;
     /**
      * Component to be injected.
      * Close the component by emitting a 'close' event — `$emit('close')`

--- a/packages/oruga/src/components/sidebar/props.ts
+++ b/packages/oruga/src/components/sidebar/props.ts
@@ -51,6 +51,11 @@ export type SidebarProps<C extends Component = Component> = {
      */
     teleport?: boolean | string | object;
     /**
+     * DOM container element for programmatic usage.
+     * @ignore internal property
+     */
+    container: HTMLElement;
+    /**
      * Component to be injected.
      * Close the component by emitting a 'close' event — `$emit('close')`
      */


### PR DESCRIPTION
## Proposed Changes

- add internal `container` property for programmatic components so the prop will not be added to $attrs and applied do component template 
