### PR TITLE
fix(table): use transition-group instead of transition for detail slot

### DIFF
--- a/packages/oruga/src/components/table/Table.vue
+++ b/packages/oruga/src/components/table/Table.vue
@@ -872,7 +872,7 @@ const showDetailRowIcon = computed(
 
 /** toggle to show/hide details slot */
 function toggleDetails(row: TableRow<T>): void {
-    if (isVisibleDetailRow(row)) {
+    if (isDetailRowVisible(row)) {
         closeDetailRow(row);
         emits("details-close", row.value);
     } else {
@@ -893,12 +893,11 @@ function closeDetailRow(row: TableRow<T>): void {
         visibleDetailedRows.value = visibleDetailedRows.value.toSpliced(idx, 1);
 }
 
-function isVisibleDetailRow(row: TableRow<T>): boolean {
-    return visibleDetailedRows.value.some((r) => isRowEqual(r, row.value));
-}
-
-function isActiveDetailRow(row: TableRow<T>): boolean {
-    return props.detailed && isVisibleDetailRow(row);
+function isDetailRowVisible(row: TableRow<T>): boolean {
+    return (
+        props.detailed &&
+        visibleDetailedRows.value.some((r) => isRowEqual(r, row.value))
+    );
 }
 
 // #endregion --- Detail Row Feature ---
@@ -1536,7 +1535,7 @@ defineExpose({ rows: tableRows, sort: sortByField });
                                     v-if="isDetailedVisible(row.value)"
                                     :icon="detailIcon"
                                     :pack="iconPack"
-                                    :rotation="isVisibleDetailRow(row) ? 90 : 0"
+                                    :rotation="isDetailRowVisible(row) ? 90 : 0"
                                     role="button"
                                     tabindex="0"
                                     clickable
@@ -1622,7 +1621,7 @@ defineExpose({ rows: tableRows, sort: sortByField });
                         <transition-group
                             v-if="props.detailed"
                             :name="detailTransition">
-                            <template v-if="isActiveDetailRow(row)">
+                            <template v-if="isDetailRowVisible(row)">
                                 <!--
                                     @slot Place row detail content here
                                     @binding {T} row - row content

--- a/packages/oruga/src/components/table/Table.vue
+++ b/packages/oruga/src/components/table/Table.vue
@@ -1619,7 +1619,7 @@ defineExpose({ rows: tableRows, sort: sortByField });
                             </td>
                         </tr>
 
-                        <transition
+                        <transition-group
                             v-if="props.detailed"
                             :name="detailTransition">
                             <template v-if="isActiveDetailRow(row)">
@@ -1650,7 +1650,7 @@ defineExpose({ rows: tableRows, sort: sortByField });
                                     </td>
                                 </tr>
                             </template>
-                        </transition>
+                        </transition-group>
                     </template>
 
                     <tr v-if="!availableRows.length" :class="trEmptyClasses">

--- a/packages/oruga/src/components/table/examples/detailed.vue
+++ b/packages/oruga/src/components/table/examples/detailed.vue
@@ -102,19 +102,19 @@ const columnsVisible = ref({
     cleared: { title: "Stock Cleared", display: true },
 });
 const showDetailIcon = ref(true);
-const showDefaultDetail = ref(true);
+const showCustomDetail = ref(true);
 const detailedRows = ref([data.value[0]]);
 </script>
 
 <template>
     <section>
         <o-field grouped multiline>
-            <o-checkbox v-model="showDetailIcon" label="Show detail chevron" />
-            <o-checkbox
-                v-model="showDefaultDetail"
-                label="Custom detail column" />
+            <o-switch v-model="showDetailIcon" label="Show detail chevron" />
+            <o-switch
+                v-model="showCustomDetail"
+                label="Custom custom detail row" />
             <div v-for="(column, index) in columnsVisible" :key="index">
-                <o-checkbox
+                <o-switch
                     v-model="column.display"
                     :label="`Show column '${column.title}'`" />
             </div>
@@ -127,7 +127,7 @@ const detailedRows = ref([data.value[0]]);
             row-key="name"
             :detailed-rows="detailedRows"
             :default-sort="['name', 'asc']"
-            :custom-detail-row="!showDefaultDetail"
+            :custom-detail-row="showCustomDetail"
             :show-detail-icon="showDetailIcon">
             <o-table-column
                 v-slot="{ row, toggleDetails }"
@@ -176,6 +176,7 @@ const detailedRows = ref([data.value[0]]);
             </o-table-column>
 
             <template #detail="{ row }">
+                <!-- when using `custom-detail-row`, make sure that each element in the slot has a unique `key` attribute -->
                 <tr v-for="item in row.items" :key="item.name">
                     <td v-if="showDetailIcon"></td>
                     <td v-show="columnsVisible['name'].display">


### PR DESCRIPTION
Fixes #1216

## Proposed Changes

- Changes `<transition>` into `<transition-group>` in the `Table` component. This fixes opening a custom detail view for a row that includes more than one row.
