### PR TITLE
refactor: switch from deprecated keypress to keydown

### DIFF
--- a/packages/oruga/src/components/carousel/Carousel.vue
+++ b/packages/oruga/src/components/carousel/Carousel.vue
@@ -594,7 +594,8 @@ function indicatorItemAppliedClasses(item: ProviderItem): ClassBind[] {
                     :aria-controls="`carouselpanel-${item.identifier}`"
                     :aria-selected="modelValue === item.index"
                     @click="onChange(item)"
-                    @keypress.enter="onChange(item)">
+                    @keydown.enter="onChange(item)"
+                    @keydown.space="onChange(item)">
                     <!--
                             @slot Override the indicator elements
                             @binding {index} index indicator index 

--- a/packages/oruga/src/components/carousel/CarouselItem.vue
+++ b/packages/oruga/src/components/carousel/CarouselItem.vue
@@ -60,7 +60,8 @@ const itemClasses = defineClasses(
         :aria-label="`${item.index + 1} of ${parent.total}`"
         draggable="true"
         @click="onClick"
-        @keypress.enter="onClick"
+        @keydown.enter="onClick"
+        @keydown.space="onClick"
         @dragstart="parent.onDrag"
         @touchstart="parent.onDrag">
         <!--

--- a/packages/oruga/src/components/dropdown/DropdownItem.vue
+++ b/packages/oruga/src/components/dropdown/DropdownItem.vue
@@ -113,8 +113,8 @@ const rootClasses = defineClasses(
         :aria-disabled="disabled"
         @click="selectItem"
         @mouseenter="focusItem"
-        @keypress.enter="selectItem"
-        @keypress.space="selectItem">
+        @keydown.enter="selectItem"
+        @keydown.space="selectItem">
         <!--
             @slot Override the label, default is label prop 
         -->


### PR DESCRIPTION
## Proposed Changes

- Switch from deprecated keydpress to keydown
- Add missing keydown space handler for "butto" type elements
