### PR TITLE
fix(autocomplete): do not open dropdown when `openOnFocus` and empty options

### DIFF
--- a/packages/oruga/src/components/autocomplete/Autocomplete.vue
+++ b/packages/oruga/src/components/autocomplete/Autocomplete.vue
@@ -168,6 +168,7 @@ const emits = defineEmits<{
 }>();
 
 const slots = useSlots();
+
 // define as Component to prevent docs memmory overload
 const inputRef = useTemplateRef<Component>("inputComponent");
 
@@ -318,7 +319,12 @@ function onInput(value: string, event: Event): void {
  * If value is the same as selected, select all text.
  */
 function handleFocus(event: Event): void {
-    if (props.openOnFocus) isActive.value = true;
+    // open dropdown if `openOnFocus` and has options
+    if (
+        props.openOnFocus &&
+        (!!props.options?.length || !!slots.header || !!slots.footer)
+    )
+        isActive.value = true;
     onFocus(event);
 }
 

--- a/packages/oruga/src/components/autocomplete/tests/autocomplete.test.ts
+++ b/packages/oruga/src/components/autocomplete/tests/autocomplete.test.ts
@@ -202,6 +202,24 @@ describe("OAutocomplete tests", () => {
         expect(dropdown.isVisible()).toBeTruthy();
     });
 
+    test("do not open when openOnFocus and empty options", async () => {
+        const wrapper = mount(OAutocomplete, {
+            props: { options: [], openOnFocus: true },
+            attachTo: document.body,
+        });
+
+        const dropdown = wrapper.find(".o-dropdown__menu");
+        expect(dropdown.exists()).toBeTruthy();
+        expect(dropdown.isVisible()).toBeFalsy();
+
+        const input = wrapper.find("input");
+        expect(input.exists()).toBeTruthy();
+
+        await input.trigger("focus");
+
+        expect(dropdown.isVisible()).toBeFalsy();
+    });
+
     test("reset events before destroy", async () => {
         document.removeEventListener = vi.fn();
         window.removeEventListener = vi.fn();


### PR DESCRIPTION
## Proposed Changes

- Do not open an empty dropdown when `openOnFocus` is set
