### PR TITLE
fix(table): show correct amount of rows when paginated

### DIFF
--- a/packages/oruga/src/components/table/Table.vue
+++ b/packages/oruga/src/components/table/Table.vue
@@ -473,7 +473,7 @@ function filterTableRows(): void {
                 tableRows.value.length > perPage &&
                 (row.index < pageStart || row.index >= pageEnd)
             )
-                // return row is invisible  (filtered out)
+                // return row is invisible (filtered out)
                 return true;
         }
 

--- a/packages/oruga/src/components/table/Table.vue
+++ b/packages/oruga/src/components/table/Table.vue
@@ -471,9 +471,9 @@ function filterTableRows(): void {
             // if not only one page and not on active page
             if (
                 tableRows.value.length > perPage &&
-                (row.index < pageStart || row.index > pageEnd)
+                (row.index < pageStart || row.index >= pageEnd)
             )
-                // return row is invisible
+                // return row is invisible  (filtered out)
                 return true;
         }
 
@@ -482,7 +482,7 @@ function filterTableRows(): void {
             // return row is visible based on filters
             return !isRowFiltered(row.value);
 
-        // return row is visible
+        // return row is visible (not filtered out)
         return false;
     });
 }

--- a/packages/oruga/src/components/table/examples/pagination.vue
+++ b/packages/oruga/src/components/table/examples/pagination.vue
@@ -263,9 +263,9 @@ const perPage = ref(3);
             :per-page="perPage"
             :pagination-simple="isPaginationSimple"
             :pagination-position="paginationPosition"
-            :default-sort-direction="defaultSortDirection"
             :sort-icon="sortIcon"
             :sort-icon-size="sortIconSize"
+            :default-sort-direction="defaultSortDirection"
             default-sort="user.first_name">
             <o-table-column
                 v-slot="{ row }"

--- a/packages/oruga/src/components/table/tests/table.test.ts
+++ b/packages/oruga/src/components/table/tests/table.test.ts
@@ -496,4 +496,46 @@ describe("OTable tests", () => {
             expect(checkboxes[0].attributes("disabled")).toBe("");
         });
     });
+
+    describe("test pageable", () => {
+        test("show correct amount of rows per page", async () => {
+            let perPage = 3;
+
+            let wrapper = mount(OTable, {
+                props: {
+                    columns: [
+                        { label: "ID", field: "id", numeric: true },
+                        { label: "Name", field: "name", searchable: true },
+                    ],
+                    paginated: true,
+                    data: data,
+                    perPage: perPage,
+                },
+            });
+            await nextTick();
+
+            let body = wrapper.find("tbody");
+            let trs = body.findAll("tr");
+            expect(trs).toHaveLength(perPage);
+
+            perPage = 5;
+
+            wrapper = mount(OTable, {
+                props: {
+                    columns: [
+                        { label: "ID", field: "id", numeric: true },
+                        { label: "Name", field: "name", searchable: true },
+                    ],
+                    paginated: true,
+                    data: data,
+                    perPage: perPage,
+                },
+            });
+            await nextTick();
+
+            body = wrapper.find("tbody");
+            trs = body.findAll("tr");
+            expect(trs).toHaveLength(perPage);
+        });
+    });
 });


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #1243 
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- fix visible row cap calculation
