### PR TITLE
fix(input): include `null` check for modelValue parsing

### DIFF
--- a/packages/oruga/src/components/input/Input.vue
+++ b/packages/oruga/src/components/input/Input.vue
@@ -125,10 +125,10 @@ const { parentField, statusVariant, statusVariantIcon } = injectField();
 
 const vmodel = defineModel<ModelValue, string, string, ModelValue>({
     // cast incomming value to string
-    get: (value) => (typeof value !== "undefined" ? String(value) : ""),
+    get: (value) => (isDefined(value) ? String(value) : ""),
     // cast outgoing value to number if prop number is true
     set: (value) =>
-        typeof value == "undefined"
+        !isDefined(value)
             ? value
             : isTrueish(props.number)
               ? Number(value)

--- a/packages/oruga/src/components/input/tests/input.test.ts
+++ b/packages/oruga/src/components/input/tests/input.test.ts
@@ -240,6 +240,17 @@ describe("OInput", () => {
         expect(emitted).toEqual([[11], [12], [13], [12], [11]]);
     });
 
+    test("check is empty when null", async () => {
+        const wrapper = mount(OInput, {
+            // @ts-expect-error special check for null instead of undefined
+            props: { modelValue: null },
+        });
+
+        const input = wrapper.find("input");
+        expect(input.exists()).toBeTruthy();
+        expect(input.element.value).toEqual("");
+    });
+
     test("react accordingly when method focus() is called", async () => {
         const wrapper = mount(OInput);
 


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #1250
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- include null check for modelValue parsing even the type is only `undefined`
