### PR TITLE
fix(table): solve sort ordering when paginated

### DIFF
--- a/packages/oruga/src/components/table/Table.vue
+++ b/packages/oruga/src/components/table/Table.vue
@@ -762,11 +762,14 @@ function sort(
 
     currentSortColumn.value = column;
 
-    // if not backend sorted, sort rows by mutating the tableRows array
-    if (!props.backendSorting) sortByColumn(tableRows.value);
+    // if not backend sorted
+    if (!props.backendSorting) {
+        // sort rows by mutating the tableRows array
+        sortByColumn(tableRows.value);
 
-    // recalculate the page filter
-    filterTableRows();
+        // recalculate the page filter
+        filterTableRows();
+    }
 }
 
 function sortByColumn(rows: TableRow<T>[]): TableRow<T>[] {

--- a/packages/oruga/src/components/table/Table.vue
+++ b/packages/oruga/src/components/table/Table.vue
@@ -465,13 +465,13 @@ function filterTableRows(): void {
     const pageEnd = pageStart + perPage;
 
     // update hidden state for each row
-    filterOptionsItems(tableRows, (row) => {
+    filterOptionsItems(tableRows, (row, idx) => {
         // if paginated not backend paginated, paginate row
         if (props.paginated || !props.backendPagination) {
             // if not only one page and not on active page
             if (
                 tableRows.value.length > perPage &&
-                (row.index < pageStart || row.index >= pageEnd)
+                (idx < pageStart || idx >= pageEnd)
             )
                 // return row is invisible (filtered out)
                 return true;
@@ -724,6 +724,16 @@ function initSort(): void {
     sortByField(sortField, sortDirection);
 }
 
+function sortByField(field: string, direction: "asc" | "desc"): void {
+    const sortColumn = tableColumns.value.find(
+        (column) => column.field === field,
+    );
+    if (sortColumn) {
+        isAsc.value = direction.toLowerCase() === "asc";
+        sort(sortColumn);
+    }
+}
+
 /**
  * Sort the column.
  * Toggle current direction on column if it's sortable
@@ -754,16 +764,9 @@ function sort(
 
     // if not backend sorted, sort rows by mutating the tableRows array
     if (!props.backendSorting) sortByColumn(tableRows.value);
-}
 
-function sortByField(field: string, direction: "asc" | "desc"): void {
-    const sortColumn = tableColumns.value.find(
-        (column) => column.field === field,
-    );
-    if (sortColumn) {
-        isAsc.value = direction.toLowerCase() === "asc";
-        sort(sortColumn);
-    }
+    // recalculate the page filter
+    filterTableRows();
 }
 
 function sortByColumn(rows: TableRow<T>[]): TableRow<T>[] {

--- a/packages/oruga/src/composables/useOptions.ts
+++ b/packages/oruga/src/composables/useOptions.ts
@@ -210,18 +210,20 @@ export function toOptionsList<V>(
  */
 export function filterOptionsItems<V>(
     options: MaybeRefOrGetter<OptionsItem<V>[] | OptionsGroupItem<V>[]>,
-    filter: (option: OptionsItem<V>) => boolean,
+    filter: (option: OptionsItem<V>, index: number) => boolean,
 ): void {
-    toValue(options).forEach((option: OptionsItem<V> | OptionsGroupItem<V>) => {
-        if (isGroupOption(option)) {
-            filterOptionsItems(option.options, filter);
-            // hide the whole group if every group options is hidden
-            option.hidden = option.options.every((option) => option.hidden);
-        } else {
-            // hide the option if filtered
-            option.hidden = filter(option);
-        }
-    });
+    toValue(options).forEach(
+        (option: OptionsItem<V> | OptionsGroupItem<V>, idx: number) => {
+            if (isGroupOption(option)) {
+                filterOptionsItems(option.options, filter);
+                // hide the whole group if every group options is hidden
+                option.hidden = option.options.every((option) => option.hidden);
+            } else {
+                // hide the option if filtered
+                option.hidden = filter(option, idx);
+            }
+        },
+    );
 }
 
 /**


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #1254
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- correct the sort behavior when paginated and not backend sorted
   - do not only sort one page - sort over the whole data set