### PR TITLE
refactor: replace `NodeJS.Timeout` type

### DIFF
--- a/packages/docs/.vitepress/theme/components/InspectorWrapper.vue
+++ b/packages/docs/.vitepress/theme/components/InspectorWrapper.vue
@@ -27,7 +27,7 @@ const data = ref({});
 const classes = ref({});
 /** applied classed of the HTML element */
 const appliedClasses = ref<string | undefined>();
-let interval: NodeJS.Timeout | undefined;
+let interval: ReturnType<typeof setTimeout> | undefined;
 
 onUnmounted(() => {
     clearTimeout(interval);

--- a/packages/oruga/src/components/carousel/Carousel.vue
+++ b/packages/oruga/src/components/carousel/Carousel.vue
@@ -258,7 +258,7 @@ function onChange(item: ProviderItem): void {
 // #region --- Autoplay Feature ---
 
 const isHovered = ref(false);
-let timer: NodeJS.Timeout | undefined;
+let timer: ReturnType<typeof setTimeout> | undefined;
 /** deactive autoplay feature */
 const isAutoplayPaused = ref(false);
 

--- a/packages/oruga/src/components/dropdown/Dropdown.vue
+++ b/packages/oruga/src/components/dropdown/Dropdown.vue
@@ -285,7 +285,7 @@ function toggle(method: string, event: Event): void {
     else close(method, event);
 }
 
-let timer: NodeJS.Timeout | undefined;
+let timer: ReturnType<typeof setTimeout> | undefined;
 
 function open(method: string, event: Event): void {
     if (props.disabled) return;

--- a/packages/oruga/src/composables/useDebounce.ts
+++ b/packages/oruga/src/composables/useDebounce.ts
@@ -10,7 +10,7 @@ export function useDebounce<A extends Array<unknown>>(
     wait: number,
     immediate?: boolean,
 ): (...args: A) => void {
-    let timeout: NodeJS.Timeout | undefined;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
     return (...args: A) => {
         const later = (): void => {
             timeout = undefined;


### PR DESCRIPTION
## Proposed Changes

- the `NodeJS.Timeout` type is only used in node environment not in browser
  - exchange the type by more a flexible solution