### PR TITLE
Bug : Autocomplete keep first does not auto focus filtered options

### DIFF
--- a/packages/oruga/src/components/autocomplete/Autocomplete.vue
+++ b/packages/oruga/src/components/autocomplete/Autocomplete.vue
@@ -239,6 +239,7 @@ watch(isEmpty, (empty) => {
 // --- Select Feature ---
 
 const dropdownValue = ref();
+const dropdownComponent = useTemplateRef("dropdownComponent");
 
 /**
  * When updating input's value:
@@ -286,6 +287,16 @@ watch(
     },
     // set initial values if selected is given
     { immediate: true },
+);
+
+watch(
+    groupedOptions,
+    () => {
+        if (props.keepFirst && isActive.value && dropdownComponent.value) {
+            dropdownComponent.value.focusFirst(true);
+        }
+    },
+    { deep: true },
 );
 
 function setSelected(item: T | SpecialOption | undefined): void {
@@ -415,6 +426,7 @@ defineExpose({ focus: setFocus, value: inputValue });
 
 <template>
     <o-dropdown
+        ref="dropdownComponent"
         v-model="dropdownValue"
         v-model:active="isActive"
         data-oruga="autocomplete"

--- a/packages/oruga/src/components/dropdown/Dropdown.vue
+++ b/packages/oruga/src/components/dropdown/Dropdown.vue
@@ -223,8 +223,7 @@ watch(
         // on active set event handler if not open as modal
         if (value) {
             // keep first option always pre-selected
-            if (!props.inline && props.keepFirst && !focusedItem.value)
-                moveFocus(1);
+            focusFirst();
         }
         if (isModal.value) toggleScroll(value);
     },
@@ -370,6 +369,20 @@ function selectItem(item: DropdownChildItem<T>, event?: Event): void {
 // #region --- Focus Feature ---
 
 const focusedItem = ref<DropdownChildItem<T>>();
+
+function focusFirst(reset = false): void {
+    if (
+        isActive.value &&
+        !props.inline &&
+        props.keepFirst &&
+        (!focusedItem.value || reset)
+    ) {
+        if (reset) focusedItem.value = undefined;
+        nextTick(() => {
+            moveFocus(1);
+        });
+    }
+}
 
 /** Hover listener from DropdownItem. */
 function focusItem(value: DropdownChildItem<T>): void {
@@ -535,7 +548,12 @@ const menuClasses = defineClasses(
 // #endregion --- Computed Component Classes ---
 
 /** expose functionalities for programmatic usage */
-defineExpose({ $trigger: triggerRef, $content: menuRef, value: vmodel });
+defineExpose({
+    $trigger: triggerRef,
+    $content: menuRef,
+    value: vmodel,
+    focusFirst,
+});
 </script>
 
 <template>


### PR DESCRIPTION
When you use the `focus-first` prop on autocomplete the expectation is that first element is auto-focused. This is crucial for keyboard-focused users who need to quickly hit enter to select the desired option. This works fine before you type into the autocomplete, the first option will be auto-focused. However when you begin to type and the list of options shortens, the new first item is not selected. If you click off and back onto the autocomplete it will correctly select the first _filtered_ element. Here's the bug in action in the docs.

https://github.com/user-attachments/assets/6c2d8cb0-7a98-4b93-a112-87571616b121

This happens because the dropdown selects the first item when it opens, and it can't be expected to react to changes in data because most usage (including autocomplete) uses a slot rather than passing data via the options prop. To solve the problem we need to allow the autocomplete to tell the dropdown when it needs to re-auto-focus.

## Proposed Changes

* Encapulates existing dropdown behaviour into a new `focusFirst()` method and exposes it for use by parents like autocomplete.
* Adds watcher in autocomplete to trigger dropdown focus when options are filtered.
