### PR TITLE
fix(notification): solve programmatic does not pass variant to notification

### DIFF
--- a/packages/oruga/src/components/notification/NotificationNotice.vue
+++ b/packages/oruga/src/components/notification/NotificationNotice.vue
@@ -208,9 +208,9 @@ defineExpose({ close });
         v-model:active="isActive"
         :override="override"
         :position="position"
+        :variant="variant"
         :role="isAlert ? 'alert' : 'status'"
         :aria-atomic="true"
-        :variant="variant"
         @close="close">
         <template #inner="{ close }">
             <!-- injected component for programmatic usage -->

--- a/packages/oruga/src/components/notification/NotificationNotice.vue
+++ b/packages/oruga/src/components/notification/NotificationNotice.vue
@@ -210,6 +210,7 @@ defineExpose({ close });
         :position="position"
         :role="isAlert ? 'alert' : 'status'"
         :aria-atomic="true"
+        :variant="variant"
         @close="close">
         <template #inner="{ close }">
             <!-- injected component for programmatic usage -->

--- a/packages/oruga/src/components/notification/tests/useNotificationProgrammatic.test.ts
+++ b/packages/oruga/src/components/notification/tests/useNotificationProgrammatic.test.ts
@@ -61,7 +61,10 @@ describe("useNotificationProgrammatic tests", () => {
 
         // open element
         const { close } = NotificationProgrammatic.open(
-            { component },
+            {
+                component,
+                variant: "success",
+            },
             "#my-cool-container",
         );
 
@@ -72,6 +75,7 @@ describe("useNotificationProgrammatic tests", () => {
             '[data-oruga="notification"]',
         );
         expect(notification).not.toBeNull();
+        expect(notification?.className).toContain("o-notification--success");
 
         // check element exist
         const button = notification?.querySelector<HTMLElement>("button");


### PR DESCRIPTION
Fixes #1282

If you check the docs, the notification page has this code which should open a success notification.

```
oruga.notification.open({
        message: "Something happened correctly!",
        variant: "success",
        closable: true,
    });
```

This code successfully sets closeable and message but it does not pass variant from the notification notice to the notification, which results in a grey default toast rather than the desired green success toast. Previous versions of Oruga (0.8.x and below) bound the notice's props to the notification by default, which passed along variant. 0.9.x instead binds `$attrs`, which does not contain variant.

To solve this problem I've added a daisy-chain to pass only variant down rather. This is not a particularly elegant solution but I'd rather stick to something conservative rather than risk regression with a more elegant refactor. @mlmoravek let me know if you have a better idea for how to do this.
