### PR TITLE
docs(tab): add additional examples

### DIFF
--- a/packages/oruga/src/components/tabs/examples/base.vue
+++ b/packages/oruga/src/components/tabs/examples/base.vue
@@ -15,7 +15,7 @@ const showBooks = ref(false);
 
         <o-tabs v-model="activeTab">
             <o-tab-item :value="0" label="Pictures" icon="image">
-                hat light is light, if Silvia be not seen? <br />
+                what light is light, if Silvia be not seen? <br />
                 What joy is joy.
             </o-tab-item>
 
@@ -44,7 +44,11 @@ const showBooks = ref(false);
                 There is no music in the nightingale.
             </o-tab-item>
 
-            <o-tab-item :value="4" label="Videos" icon="video" disabled>
+            <o-tab-item :value="4" label="Words">
+                This text is much longer than the other examples. The most merciful thing in the world, I think, is the inability of the human mind to correlate all its contents. We live on a placid island of ignorance in the midst of black seas of infinity, and it was not meant that we should voyage far. The sciences, each straining in its own direction, have hitherto harmed us little; but some day the piecing together of dissociated knowledge will open up such terrifying vistas of reality, and of our frightful position therein, that we shall either go mad from the revelation or flee from the deadly light into the peace and safety of a new dark age.
+            </o-tab-item>
+
+            <o-tab-item :value="5" label="Videos" icon="video" disabled>
                 Nunc nec velit nec libero vestibulum eleifend. Curabitur
                 pulvinar congue luctus. Nullam hendrerit iaculis augue vitae
                 ornare. Maecenas vehicula pulvinar tellus, id sodales felis

--- a/packages/oruga/src/components/tabs/examples/expanded.vue
+++ b/packages/oruga/src/components/tabs/examples/expanded.vue
@@ -8,5 +8,3 @@
         </o-tabs>
     </section>
 </template>
-<script setup lang="ts">
-</script>

--- a/packages/oruga/src/components/tabs/examples/expanded.vue
+++ b/packages/oruga/src/components/tabs/examples/expanded.vue
@@ -3,7 +3,10 @@
         <o-tabs expanded>
             <o-tab-item label="Pictures" icon="images" />
             <o-tab-item label="Music" icon="music" />
+            <o-tab-item label="Words" />
             <o-tab-item label="Videos" icon="video" />
         </o-tabs>
     </section>
 </template>
+<script setup lang="ts">
+</script>

--- a/packages/oruga/src/components/tabs/examples/long-header.vue
+++ b/packages/oruga/src/components/tabs/examples/long-header.vue
@@ -4,7 +4,8 @@
             <o-tab-item
                 v-for="(item, index) in new Array(45)"
                 :key="`longitem-${index}`"
-                :label="`Head ${index}`" />
+                :label="`Head ${index}`"
+                :icon="index % 2 === 0 ? 'book' : ''" />
         </o-tabs>
     </section>
 </template>

--- a/packages/oruga/src/components/tabs/examples/position.vue
+++ b/packages/oruga/src/components/tabs/examples/position.vue
@@ -3,19 +3,24 @@
         <o-tabs type="boxed" position="left">
             <o-tab-item label="Pictures" icon="images" />
             <o-tab-item label="Music" icon="music" />
+            <o-tab-item label="Words" />
             <o-tab-item label="Videos" icon="video" />
         </o-tabs>
 
         <o-tabs type="boxed" position="centered">
             <o-tab-item label="Pictures" icon="images" />
             <o-tab-item label="Music" icon="music" />
+            <o-tab-item label="Words" />
             <o-tab-item label="Videos" icon="video" />
         </o-tabs>
 
         <o-tabs type="boxed" position="right">
             <o-tab-item label="Pictures" icon="images" />
             <o-tab-item label="Music" icon="music" />
+            <o-tab-item label="Words" />
             <o-tab-item label="Videos" icon="video" />
         </o-tabs>
     </section>
 </template>
+<script setup lang="ts">
+</script>

--- a/packages/oruga/src/components/tabs/examples/position.vue
+++ b/packages/oruga/src/components/tabs/examples/position.vue
@@ -22,5 +22,3 @@
         </o-tabs>
     </section>
 </template>
-<script setup lang="ts">
-</script>

--- a/packages/oruga/src/components/tabs/examples/sizes.vue
+++ b/packages/oruga/src/components/tabs/examples/sizes.vue
@@ -24,8 +24,12 @@ const options: OptionsProp = [
         },
     },
     {
-        label: "Videos",
+        label: "Words",
         value: 3,
+    },
+    {
+        label: "Videos",
+        value: 4,
         attrs: {
             icon: "video",
             disabled: true,

--- a/packages/oruga/src/components/tabs/examples/types.vue
+++ b/packages/oruga/src/components/tabs/examples/types.vue
@@ -4,6 +4,7 @@
             <o-tabs type="boxed">
                 <o-tab-item label="Pictures" icon="images" />
                 <o-tab-item label="Music" icon="music" />
+                <o-tab-item label="Words" />
                 <o-tab-item label="Videos" icon="video" />
             </o-tabs>
         </o-field>
@@ -12,6 +13,7 @@
             <o-tabs type="toggle">
                 <o-tab-item label="Pictures" icon="images" />
                 <o-tab-item label="Music" icon="music" />
+                <o-tab-item label="Words" />
                 <o-tab-item label="Videos" icon="video" />
             </o-tabs>
         </o-field>
@@ -20,6 +22,7 @@
             <o-tabs type="pills">
                 <o-tab-item label="Pictures" icon="images" />
                 <o-tab-item label="Music" icon="music" />
+                <o-tab-item label="Words" />
                 <o-tab-item label="Videos" icon="video" />
             </o-tabs>
         </o-field>

--- a/packages/oruga/src/components/tabs/examples/vertical.vue
+++ b/packages/oruga/src/components/tabs/examples/vertical.vue
@@ -61,6 +61,10 @@ const type = ref("default");
                 There is no music in the nightingale.
             </o-tab-item>
 
+            <o-tab-item label="Words">
+                <p>This text is much longer than the other examples. The most merciful thing in the world, I think, is the inability of the human mind to correlate all its contents. We live on a placid island of ignorance in the midst of black seas of infinity, and it was not meant that we should voyage far. The sciences, each straining in its own direction, have hitherto harmed us little; but some day the piecing together of dissociated knowledge will open up such terrifying vistas of reality, and of our frightful position therein, that we shall either go mad from the revelation or flee from the deadly light into the peace and safety of a new dark age.</p>
+            </o-tab-item>
+
             <o-tab-item label="Videos" icon="video" disabled>
                 Nunc nec velit nec libero vestibulum eleifend. Curabitur
                 pulvinar congue luctus. Nullam hendrerit iaculis augue vitae


### PR DESCRIPTION
Our tab examples feature very reasonable content. Unfortunately, we do not live in a reasonable world and our components should work as well as can be expected even when our users do unreasonable things. This PR adds some examples to the docs which expose a few edge case bugs in our themes.

## Proposed Changes

- Adds tabs to makes most examples show a mixture of tabs with and without icons to test for height bugs.
- Adds one tab with content which is much longer with no BRs to test wrapping etc when height changes.

## Issues Exposed

### Bootstrap

Tab height issues at medium/large size

<img width="953" alt="Screenshot 2025-04-14 at 11 22 25 AM" src="https://github.com/user-attachments/assets/f0be1030-7cc5-43fa-85a8-d147b29a3784" />

Vertical tab collapses with large content

https://github.com/user-attachments/assets/10644340-05ea-4b04-be7b-648f804d7413

### Bulma

Tab height issues (not all shown)

<img width="634" alt="Screenshot 2025-04-14 at 11 27 14 AM" src="https://github.com/user-attachments/assets/aacfc986-7551-44da-81e1-a93742762d5c" />

Vertical tab wraps with large content


https://github.com/user-attachments/assets/4fbf184f-6666-4d7f-b092-1a24517764bc


I plan to do a theme Bulma PR to address those issues. I may be able to do bootstrap as well if time permits.