### PR TITLE
fix(autocomplete): keep first does not auto focus filtered options (round 2)

### DIFF
--- a/packages/oruga/src/components/dropdown/Dropdown.vue
+++ b/packages/oruga/src/components/dropdown/Dropdown.vue
@@ -231,6 +231,17 @@ watch(
     { flush: "post" },
 );
 
+watch(
+    () => childItems.value,
+    () => {
+        if (isActive.value && !props.inline && props.keepFirst) {
+            focusedItem.value = undefined;
+            moveFocus(1);
+        }
+    },
+    { deep: true, flush: "post" },
+);
+
 // #region --- Trigger Handler ---
 
 /** Close dropdown if clicked outside. */


### PR DESCRIPTION
When you use the `focus-first` prop on autocomplete the expectation is that first option is auto-focused. This is crucial for keyboard-focused users who need to quickly hit enter to select the desired option. This works fine before you type into the autocomplete, the first option will be auto-focused. However when you begin to type and the list of options shortens, the new first item is not selected. If you click off and back onto the autocomplete it will correctly select the first _filtered_ element. Here's the bug in action in the docs.

https://github.com/user-attachments/assets/ac4b76cb-11db-4c30-a704-f69026ae6d8d

This happens because the dropdown selects the first item when it opens, and it can't be expected to react to changes in data because most usage (including autocomplete) uses a slot rather than passing data via the options prop. To solve the problem we need to allow the autocomplete to tell the dropdown when it needs to re-auto-focus.

## Proposed Changes

* Adds new watcher to dropdown to re-focus when children change.
