### PR TITLE
fix(programmatic): resolve inconsistent `close` event args

### DIFF
--- a/packages/oruga/src/components/loading/Loading.vue
+++ b/packages/oruga/src/components/loading/Loading.vue
@@ -99,7 +99,7 @@ function cancel(method: string): void {
 /** set active to false and emit close event */
 function close(...args: unknown[]): void {
     isActive.value = false;
-    emits("close", args);
+    emits("close", ...args);
 }
 
 // --- Computed Component Classes ---

--- a/packages/oruga/src/components/loading/tests/useLoadingProgrammatic.test.ts
+++ b/packages/oruga/src/components/loading/tests/useLoadingProgrammatic.test.ts
@@ -2,7 +2,6 @@ import { describe, test, expect, afterEach, vi, beforeEach } from "vitest";
 import { enableAutoUnmount, flushPromises } from "@vue/test-utils";
 
 import LoadingProgrammatic from "../useLoadingProgrammatic";
-import { createVNode } from "vue";
 
 describe("useLoadingProgrammatic tests", () => {
     beforeEach(() => {

--- a/packages/oruga/src/components/loading/tests/useLoadingProgrammatic.test.ts
+++ b/packages/oruga/src/components/loading/tests/useLoadingProgrammatic.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, afterEach, vi, beforeEach } from "vitest";
 import { enableAutoUnmount, flushPromises } from "@vue/test-utils";
 
 import LoadingProgrammatic from "../useLoadingProgrammatic";
+import { createVNode } from "vue";
 
 describe("useLoadingProgrammatic tests", () => {
     beforeEach(() => {
@@ -35,7 +36,7 @@ describe("useLoadingProgrammatic tests", () => {
         close();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         loading = document.body.querySelector('[data-oruga="loading"]');
         expect(loading).toBeNull();
 
@@ -64,7 +65,7 @@ describe("useLoadingProgrammatic tests", () => {
         close();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         loading = document.body.querySelector('[data-oruga="loading"]');
         expect(loading).toBeNull();
 
@@ -90,7 +91,7 @@ describe("useLoadingProgrammatic tests", () => {
         close();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         loading = document.body.querySelector('[data-oruga="loading"]');
         expect(loading).toBeNull();
     });
@@ -114,7 +115,7 @@ describe("useLoadingProgrammatic tests", () => {
         close();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         loading = document.body.querySelector('[data-oruga="loading"]');
         expect(loading).toBeNull();
 

--- a/packages/oruga/src/components/modal/Modal.vue
+++ b/packages/oruga/src/components/modal/Modal.vue
@@ -164,7 +164,7 @@ function cancel(method: string): void {
 /** set active to false and emit close event */
 function close(...args: unknown[]): void {
     isActive.value = false;
-    emits("close", args);
+    emits("close", ...args);
 }
 
 // --- Animation Feature ---

--- a/packages/oruga/src/components/modal/tests/useModalProgrammatic.test.ts
+++ b/packages/oruga/src/components/modal/tests/useModalProgrammatic.test.ts
@@ -148,6 +148,6 @@ describe("useModalProgrammatic tests", () => {
         el = document.body.querySelector("button");
         expect(el).toBeNull();
 
-        expect(onClose).toHaveBeenCalledWith({action: 'ok'});
+        expect(onClose).toHaveBeenCalledWith({ action: 'ok' });
     });
 });

--- a/packages/oruga/src/components/modal/tests/useModalProgrammatic.test.ts
+++ b/packages/oruga/src/components/modal/tests/useModalProgrammatic.test.ts
@@ -38,7 +38,7 @@ describe("useModalProgrammatic tests", () => {
         close();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         modal = document.body.querySelector('[data-oruga="modal"]');
         expect(modal).toBeNull();
 
@@ -67,7 +67,7 @@ describe("useModalProgrammatic tests", () => {
         close();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         modal = document.body.querySelector('[data-oruga="modal"]');
         expect(modal).toBeNull();
 
@@ -100,12 +100,12 @@ describe("useModalProgrammatic tests", () => {
         button?.click();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         modal = document.body.querySelector('[data-oruga="modal"]');
         expect(modal).toBeNull();
     });
 
-    test("test close event working correctly", async () => {
+    test("test internal close (x) event working correctly", async () => {
         const content = "My Modal Content";
         const onClose = vi.fn();
 
@@ -120,10 +120,34 @@ describe("useModalProgrammatic tests", () => {
         el?.click();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         el = document.body.querySelector("button");
         expect(el).toBeNull();
 
         expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    test("test external close event working correctly", async () => {
+        const component = createVNode({
+            template: `<button @click="$emit('close', {action: 'ok'})">Fancy Label</button>`,
+        });
+        const onClose = vi.fn();
+
+        // open element
+        ModalProgrammatic.open({ component, onClose });
+
+        // check element exist
+        let el = document.body.querySelector<HTMLElement>("button");
+        expect(el).not.toBeNull();
+
+        // close element on 'x' button click
+        el?.click();
+        vi.runAllTimers();
+
+        // check element does not exist
+        el = document.body.querySelector("button");
+        expect(el).toBeNull();
+
+        expect(onClose).toHaveBeenCalledWith({action: 'ok'});
     });
 });

--- a/packages/oruga/src/components/modal/tests/useModalProgrammatic.test.ts
+++ b/packages/oruga/src/components/modal/tests/useModalProgrammatic.test.ts
@@ -148,6 +148,6 @@ describe("useModalProgrammatic tests", () => {
         el = document.body.querySelector("button");
         expect(el).toBeNull();
 
-        expect(onClose).toHaveBeenCalledWith({ action: 'ok' });
+        expect(onClose).toHaveBeenCalledWith({ action: "ok" });
     });
 });

--- a/packages/oruga/src/components/notification/NotificationNotice.vue
+++ b/packages/oruga/src/components/notification/NotificationNotice.vue
@@ -191,7 +191,7 @@ function onMouseLeave(): void {
 function close(...args: unknown[]): void {
     isActive.value = false;
     if (timer) clearTimeout(timer);
-    emits("close", args);
+    emits("close", ...args);
 }
 
 // --- Computed Component Classes ---

--- a/packages/oruga/src/components/notification/tests/useNotificationProgrammatic.test.ts
+++ b/packages/oruga/src/components/notification/tests/useNotificationProgrammatic.test.ts
@@ -154,6 +154,6 @@ describe("useNotificationProgrammatic tests", () => {
         el = document.body.querySelector("button");
         expect(el).toBeNull();
 
-        expect(onClose).toHaveBeenCalledWith({ action: 'ok' });
+        expect(onClose).toHaveBeenCalledWith({ action: "ok" });
     });
 });

--- a/packages/oruga/src/components/notification/tests/useNotificationProgrammatic.test.ts
+++ b/packages/oruga/src/components/notification/tests/useNotificationProgrammatic.test.ts
@@ -154,6 +154,6 @@ describe("useNotificationProgrammatic tests", () => {
         el = document.body.querySelector("button");
         expect(el).toBeNull();
 
-        expect(onClose).toHaveBeenCalledWith({action: 'ok'});
+        expect(onClose).toHaveBeenCalledWith({ action: 'ok' });
     });
 });

--- a/packages/oruga/src/components/notification/tests/useNotificationProgrammatic.test.ts
+++ b/packages/oruga/src/components/notification/tests/useNotificationProgrammatic.test.ts
@@ -40,7 +40,7 @@ describe("useNotificationProgrammatic tests", () => {
         close();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         notification = document.body.querySelector(
             '[data-oruga="notification"]',
         );
@@ -89,7 +89,7 @@ describe("useNotificationProgrammatic tests", () => {
         close();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         notification = document.body.querySelector(
             '[data-oruga="notification"]',
         );
@@ -126,7 +126,7 @@ describe("useNotificationProgrammatic tests", () => {
         button?.click();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         notification = document.body.querySelector(
             '[data-oruga="notification"]',
         );
@@ -135,7 +135,7 @@ describe("useNotificationProgrammatic tests", () => {
 
     test("test close event working correctly", async () => {
         const component = createVNode({
-            template: `<button @click="$emit('close', 'abc')">Fancy Label</button>`,
+            template: `<button @click="$emit('close', {action: 'ok'})">Fancy Label</button>`,
         });
         const onClose = vi.fn();
 
@@ -150,10 +150,10 @@ describe("useNotificationProgrammatic tests", () => {
         el?.click();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         el = document.body.querySelector("button");
         expect(el).toBeNull();
 
-        expect(onClose).toHaveBeenCalledOnce();
+        expect(onClose).toHaveBeenCalledWith({action: 'ok'});
     });
 });

--- a/packages/oruga/src/components/programmatic/tests/useProgrammatic.test.ts
+++ b/packages/oruga/src/components/programmatic/tests/useProgrammatic.test.ts
@@ -39,7 +39,7 @@ describe("useProgrammatic tests", () => {
         close();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         el = document.body.querySelector("#mycomp");
         expect(el).toBeNull();
 
@@ -72,7 +72,7 @@ describe("useProgrammatic tests", () => {
         close();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         el = document.body.querySelector("#mycomp");
         expect(el).toBeNull();
 
@@ -99,7 +99,7 @@ describe("useProgrammatic tests", () => {
         el?.click();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         el = document.body.querySelector("button");
         expect(el).toBeNull();
 
@@ -127,7 +127,7 @@ describe("useProgrammatic tests", () => {
         close();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         el = document.body.querySelector<HTMLButtonElement>(
             '[data-oruga="programmatic"]',
         );

--- a/packages/oruga/src/components/sidebar/Sidebar.vue
+++ b/packages/oruga/src/components/sidebar/Sidebar.vue
@@ -165,7 +165,7 @@ function cancel(method: string): void {
 /** set active to false and emit close event */
 function close(...args: unknown[]): void {
     isActive.value = false;
-    emits("close", args);
+    emits("close", ...args);
 }
 
 // --- Animation Feature ---

--- a/packages/oruga/src/components/sidebar/tests/useSidebarProgrammatic.test.ts
+++ b/packages/oruga/src/components/sidebar/tests/useSidebarProgrammatic.test.ts
@@ -135,6 +135,6 @@ describe("useSidebarProgrammatic tests", () => {
         el = document.body.querySelector("button");
         expect(el).toBeNull();
 
-        expect(onClose).toHaveBeenCalledWith({ action: 'ok' });
+        expect(onClose).toHaveBeenCalledWith({ action: "ok" });
     });
 });

--- a/packages/oruga/src/components/sidebar/tests/useSidebarProgrammatic.test.ts
+++ b/packages/oruga/src/components/sidebar/tests/useSidebarProgrammatic.test.ts
@@ -135,6 +135,6 @@ describe("useSidebarProgrammatic tests", () => {
         el = document.body.querySelector("button");
         expect(el).toBeNull();
 
-        expect(onClose).toHaveBeenCalledWith({action: 'ok'});
+        expect(onClose).toHaveBeenCalledWith({ action: 'ok' });
     });
 });

--- a/packages/oruga/src/components/sidebar/tests/useSidebarProgrammatic.test.ts
+++ b/packages/oruga/src/components/sidebar/tests/useSidebarProgrammatic.test.ts
@@ -40,7 +40,7 @@ describe("useSidebarProgrammatic tests", () => {
         close();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         sidebar = document.body.querySelector('[data-oruga="sidebar"]');
         expect(sidebar).toBeNull();
 
@@ -76,7 +76,7 @@ describe("useSidebarProgrammatic tests", () => {
         close();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         sidebar = document.body.querySelector('[data-oruga="sidebar"]');
         expect(sidebar).toBeNull();
 
@@ -109,14 +109,14 @@ describe("useSidebarProgrammatic tests", () => {
         button?.click();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         sidebar = document.body.querySelector('[data-oruga="sidebar"]');
         expect(sidebar).toBeNull();
     });
 
     test("test close event working correctly", async () => {
         const component = createVNode({
-            template: `<button @click="$emit('close', 'abc')">Fancy Label</button>`,
+            template: `<button @click="$emit('close', {action: 'ok'})">Fancy Label</button>`,
         });
         const onClose = vi.fn();
 
@@ -131,10 +131,10 @@ describe("useSidebarProgrammatic tests", () => {
         el?.click();
         vi.runAllTimers();
 
-        // check element does not edist
+        // check element does not exist
         el = document.body.querySelector("button");
         expect(el).toBeNull();
 
-        expect(onClose).toHaveBeenCalledOnce();
+        expect(onClose).toHaveBeenCalledWith({action: 'ok'});
     });
 });


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #1305
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- spread the close event arguments while emitting the `close` event.
- fix comment typo
- update tests
