### PR TITLE
refactor(icon): replace internal `both` prop with global config

### DIFF
--- a/packages/docs/.vitepress/theme/index.ts
+++ b/packages/docs/.vitepress/theme/index.ts
@@ -11,7 +11,7 @@ import InspectorWrapper from "./components/InspectorWrapper.vue";
 import ExampleViewer from "./components/ExampleViewer.vue";
 import Expo from "./components/Expo.vue";
 
-import Oruga from "@oruga-ui/oruga-next";
+import Oruga, { type OrugaOptions } from "@oruga-ui/oruga-next";
 
 import { bulmaConfig } from "@oruga-ui/theme-bulma";
 import { bootstrapConfig } from "@oruga-ui/theme-bootstrap";
@@ -112,7 +112,8 @@ export default {
         }
 
         // basic docs config
-        let orugaConfig = {
+        let orugaConfig: OrugaOptions = {
+            environment: "docs",
             iconPack: "fas",
             iconComponent: "vue-fontawesome",
         };

--- a/packages/oruga/src/components/button/Button.vue
+++ b/packages/oruga/src/components/button/Button.vue
@@ -35,7 +35,6 @@ const props = withDefaults(defineProps<ButtonProps>(), {
     iconPack: () => getDefault("button.iconPack"),
     iconLeft: undefined,
     iconRight: undefined,
-    iconBoth: false,
 });
 
 defineEmits<{
@@ -144,7 +143,6 @@ const iconRightClasses = defineClasses([
                 :pack="iconPack"
                 :icon="iconLeft"
                 :size="size"
-                :both="iconBoth"
                 :class="[...iconClasses, ...iconLeftClasses]" />
 
             <span v-if="label || $slots.default" :class="labelClasses">
@@ -159,7 +157,6 @@ const iconRightClasses = defineClasses([
                 :pack="iconPack"
                 :icon="iconRight"
                 :size="size"
-                :both="iconBoth"
                 :class="[...iconClasses, ...iconRightClasses]" />
         </span>
     </component>

--- a/packages/oruga/src/components/button/props.ts
+++ b/packages/oruga/src/components/button/props.ts
@@ -46,11 +46,6 @@ export type ButtonProps = {
      * @values button, submit, reset
      */
     type?: "button" | "submit" | "reset";
-    /**
-     * This is used internally
-     * @ignore
-     */
-    iconBoth?: boolean;
 } & ButtonClasses;
 
 // class props (will not be displayed in the docs)

--- a/packages/oruga/src/components/carousel/Carousel.vue
+++ b/packages/oruga/src/components/carousel/Carousel.vue
@@ -498,7 +498,6 @@ function indicatorItemAppliedClasses(item: ProviderItem): ClassBind[] {
                                 : iconAutoplayResume
                         "
                         :size="iconSize"
-                        both
                         role="button"
                         tabindex="0"
                         :aria-label="
@@ -532,7 +531,6 @@ function indicatorItemAppliedClasses(item: ProviderItem): ClassBind[] {
                         :pack="iconPack"
                         :icon="iconPrev"
                         :size="iconSize"
-                        both
                         role="button"
                         tabindex="0"
                         :aria-label="ariaPreviousLabel"
@@ -545,7 +543,6 @@ function indicatorItemAppliedClasses(item: ProviderItem): ClassBind[] {
                         :pack="iconPack"
                         :icon="iconNext"
                         :size="iconSize"
-                        both
                         role="button"
                         tabindex="0"
                         :aria-label="ariaNextLabel"

--- a/packages/oruga/src/components/icon/Icon.vue
+++ b/packages/oruga/src/components/icon/Icon.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
-import { getDefault } from "@/utils/config";
+import { getDefault, getOption } from "@/utils/config";
 import getIcons from "@/utils/icons";
 import { defineClasses } from "@/composables";
 
@@ -30,33 +30,33 @@ const props = withDefaults(defineProps<IconProps>(), {
     clickable: false,
     spin: false,
     rotation: undefined,
-    both: false,
 });
+
+const environment = getOption("environment");
 
 const rootStyle = computed(() => {
     const style = {};
-    if (props.rotation) {
-        style["transform"] = `rotate(${props.rotation}deg)`;
-    }
+    if (props.rotation) style["transform"] = `rotate(${props.rotation}deg)`;
     return style;
 });
 
-const iconConfig = computed(() => getIcons()[props.pack]);
+const icons = getIcons();
 
-const iconPrefix = computed(() =>
-    iconConfig.value?.iconPrefix ? iconConfig.value.iconPrefix : "",
-);
+const iconConfig = computed(() => icons[props.pack]);
+
+const iconPrefix = computed(() => iconConfig.value?.iconPrefix ?? "");
 
 const customSizeByPack = computed(() => {
     if (iconConfig.value?.sizes) {
-        if (props.size && iconConfig.value.sizes[props.size] !== undefined) {
+        if (props.size && iconConfig.value.sizes[props.size] !== undefined)
             return iconConfig.value.sizes[props.size];
-        } else if (iconConfig.value.sizes.default) {
+        else if (iconConfig.value.sizes.default)
             return iconConfig.value.sizes.default;
-        }
     }
     return null;
 });
+
+const computedSize = computed(() => props.customSize || customSizeByPack.value);
 
 /**
  * Internal icon name based on the pack.
@@ -64,28 +64,13 @@ const customSizeByPack = computed(() => {
  * internal icons are always MDI.
  */
 const computedIcon = computed(
-    () => `${iconPrefix.value}${getEquivalentIconOf(props.icon)}`,
+    () => `${iconPrefix.value}${getEquivalentIconOf(props.icon ?? "")}`,
 );
 
-const computedSize = computed(() => props.customSize || customSizeByPack.value);
-
-const computedVariant = computed(() => {
-    if (!props.variant) return;
-    let newVariant = "";
-    if (typeof props.variant === "string") {
-        newVariant = props.variant;
-    } else {
-        newVariant = Object.keys(props.variant).filter(
-            (key) => props.variant[key],
-        )[0];
-    }
-    return newVariant;
-});
-
 /** Equivalent icon name of the MDI. */
-function getEquivalentIconOf(value): string {
-    // Only transform the class if the both prop is set to true
-    if (!props.both) return value;
+function getEquivalentIconOf(value: string): string {
+    // Only transform the class if the env is docs prop is set to true
+    if (environment != "docs") return value;
     if (
         iconConfig.value?.internalIcons &&
         iconConfig.value?.internalIcons[value]
@@ -114,8 +99,8 @@ const rootClasses = defineClasses(
     [
         "variantClass",
         "o-icon--",
-        computedVariant,
-        computed(() => !!computedVariant.value),
+        computed(() => props.variant),
+        computed(() => !!props.variant),
     ],
 );
 </script>

--- a/packages/oruga/src/components/icon/examples/base.vue
+++ b/packages/oruga/src/components/icon/examples/base.vue
@@ -20,9 +20,7 @@
 
         <p>
             <o-icon pack="fas" icon="user" size="large" variant="success" />
-
             <o-icon pack="fas" icon="home" size="large" variant="info" />
-
             <o-icon
                 pack="fas"
                 icon="tachometer-alt"

--- a/packages/oruga/src/components/icon/props.ts
+++ b/packages/oruga/src/components/icon/props.ts
@@ -38,11 +38,6 @@ export type IconProps = {
     spin?: boolean;
     /** Rotation 0-360 */
     rotation?: number | string;
-    /**
-     * This is used internally
-     * @ignore
-     */
-    both?: boolean;
 } & IconClasses;
 
 // class props (will not be displayed in the docs)

--- a/packages/oruga/src/components/icon/tests/__snapshots__/icon.test.ts.snap
+++ b/packages/oruga/src/components/icon/tests/__snapshots__/icon.test.ts.snap
@@ -1,3 +1,3 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`OIcon tests > render correctly 1`] = `"<span data-oruga="icon" class="o-icon"><!-- custom icon component --><!-- native css icon --><i class="mdi mdi-undefined mdi-24px"></i></span>"`;
+exports[`OIcon tests > render correctly 1`] = `"<span data-oruga="icon" class="o-icon"><!-- custom icon component --><!-- native css icon --><i class="mdi mdi- mdi-24px"></i></span>"`;

--- a/packages/oruga/src/components/input/Input.vue
+++ b/packages/oruga/src/components/input/Input.vue
@@ -402,7 +402,6 @@ defineExpose({ focus: setFocus, value: vmodel });
             :pack="iconPack"
             :size="size"
             :variant="computedIconRightVariant"
-            both
             @click="rightIconClick" />
 
         <small

--- a/packages/oruga/src/components/loading/Loading.vue
+++ b/packages/oruga/src/components/loading/Loading.vue
@@ -143,8 +143,7 @@ defineExpose({ close });
                     :icon="icon"
                     :spin="iconSpin"
                     :size="iconSize"
-                    :class="iconClasses"
-                    both />
+                    :class="iconClasses" />
                 <span v-if="label" :class="labelClasses">
                     {{ label }}
                 </span>

--- a/packages/oruga/src/components/modal/Modal.vue
+++ b/packages/oruga/src/components/modal/Modal.vue
@@ -254,7 +254,6 @@ defineExpose({ close });
                         :icon="closeIcon"
                         :size="closeIconSize"
                         clickable
-                        both
                         @click="cancel('x')" />
                 </div>
             </div>

--- a/packages/oruga/src/components/notification/Notification.vue
+++ b/packages/oruga/src/components/notification/Notification.vue
@@ -134,8 +134,7 @@ const closeClasses = defineClasses(["closeClass", "o-notification__close"]);
                     clickable
                     :pack="iconPack"
                     :icon="closeIcon"
-                    :size="closeIconSize"
-                    both />
+                    :size="closeIconSize" />
             </button>
 
             <!--
@@ -151,7 +150,6 @@ const closeClasses = defineClasses(["closeClass", "o-notification__close"]);
                     :pack="iconPack"
                     :class="iconClasses"
                     :size="iconSize"
-                    both
                     aria-hidden />
                 <div :class="contentClasses">
                     <!--

--- a/packages/oruga/src/components/pagination/Pagination.vue
+++ b/packages/oruga/src/components/pagination/Pagination.vue
@@ -274,11 +274,7 @@ defineExpose({ last, first, prev, next });
                 :root-class="buttonPrevClasses"
                 :button-class="buttonClasses"
                 :button-current-class="buttonCurrentClasses">
-                <o-icon
-                    :icon="iconPrev"
-                    :pack="iconPack"
-                    both
-                    aria-hidden="true" />
+                <o-icon :icon="iconPrev" :pack="iconPack" aria-hidden="true" />
             </o-pagination-button>
         </slot>
 
@@ -296,11 +292,7 @@ defineExpose({ last, first, prev, next });
                 :root-class="buttonNextClasses"
                 :button-class="buttonClasses"
                 :button-current-class="buttonCurrentClasses">
-                <o-icon
-                    :icon="iconNext"
-                    :pack="iconPack"
-                    both
-                    aria-hidden="true" />
+                <o-icon :icon="iconNext" :pack="iconPack" aria-hidden="true" />
             </o-pagination-button>
         </slot>
 

--- a/packages/oruga/src/components/select/Select.vue
+++ b/packages/oruga/src/components/select/Select.vue
@@ -350,7 +350,6 @@ defineExpose({ focus: setFocus, value: vmodel });
             :pack="iconPack"
             :size="size"
             :variant="rightIconVariant"
-            both
             @click="rightIconClick" />
     </div>
 </template>

--- a/packages/oruga/src/components/steps/Steps.vue
+++ b/packages/oruga/src/components/steps/Steps.vue
@@ -403,7 +403,6 @@ const navigationClasses = defineClasses([
                     role="button"
                     :icon-left="iconPrev"
                     :icon-pack="iconPack"
-                    icon-both
                     :disabled="!hasPrev"
                     :aria-label="ariaPreviousLabel"
                     @click.prevent="activateItem(-1)" />
@@ -412,7 +411,6 @@ const navigationClasses = defineClasses([
                     role="button"
                     :icon-left="iconNext"
                     :icon-pack="iconPack"
-                    icon-both
                     :disabled="!hasNext"
                     :aria-label="ariaNextLabel"
                     @click.prevent="activateItem(1)" />

--- a/packages/oruga/src/components/table/Table.vue
+++ b/packages/oruga/src/components/table/Table.vue
@@ -1353,7 +1353,6 @@ defineExpose({ rows: tableRows, sort: sortByField });
                                         <o-icon
                                             :icon="sortIcon"
                                             :pack="iconPack"
-                                            both
                                             :size="sortIconSize"
                                             :rotation="!isAsc ? 180 : 0" />
                                     </span>
@@ -1546,7 +1545,6 @@ defineExpose({ rows: tableRows, sort: sortByField });
                                     role="button"
                                     tabindex="0"
                                     clickable
-                                    both
                                     :aria-label="`Open ${row.label} details`"
                                     @click.prevent="toggleDetails(row)"
                                     @keydown.prevent.enter="toggleDetails(row)"
@@ -1670,8 +1668,7 @@ defineExpose({ rows: tableRows, sort: sortByField });
                                     v-if="emptyIcon"
                                     :icon="emptyIcon"
                                     :size="emptyIconSize"
-                                    :pack="iconPack"
-                                    both />
+                                    :pack="iconPack" />
                                 {{ emptyLabel }}
                             </slot>
                         </td>

--- a/packages/oruga/src/components/table/TableMobileSort.vue
+++ b/packages/oruga/src/components/table/TableMobileSort.vue
@@ -101,7 +101,6 @@ function sort(event: Event): void {
                     :icon="sortIcon"
                     :pack="iconPack"
                     :size="sortIconSize"
-                    both
                     :rotation="!isAsc ? 180 : 0" />
             </o-button>
         </o-field>

--- a/packages/oruga/src/components/tag/Tag.vue
+++ b/packages/oruga/src/components/tag/Tag.vue
@@ -90,8 +90,7 @@ const closeClasses = defineClasses(["closeClass", "o-tag_close_icon"]);
             :class="iconClasses"
             :pack="iconPack"
             :icon="icon"
-            :size="size"
-            both />
+            :size="size" />
 
         <span :class="labelClasses">
             <!--
@@ -115,10 +114,9 @@ const closeClasses = defineClasses(["closeClass", "o-tag_close_icon"]);
                 tabindex="0"
                 role="button"
                 :aria-label="ariaCloseLabel"
-                both
+                @click="close"
                 @keyup.enter="close"
-                @keyup.space="close"
-                @click="close" />
+                @keyup.space="close" />
         </slot>
     </div>
 </template>

--- a/packages/oruga/src/components/tag/tests/__snapshots__/tag.test.ts.snap
+++ b/packages/oruga/src/components/tag/tests/__snapshots__/tag.test.ts.snap
@@ -1,18 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`BTag > render correctly 1`] = `
-"<div data-oruga="tag" class="o-tag">
-  <!--v-if--><span class="o-tag__label"><!--
-                @slot Override the tag label
-            -->My Tag</span>
-  <!--
-            @slot Override the close icon
-            @binding {close()} close - close function
-        -->
-  <!--v-if-->
-</div>"
-`;
-
 exports[`OTag tests > render correctly 1`] = `
 "<div data-oruga="tag" class="o-tag">
   <!--v-if--><span class="o-tag__label"><!--

--- a/packages/oruga/src/components/taginput/Taginput.vue
+++ b/packages/oruga/src/components/taginput/Taginput.vue
@@ -354,9 +354,8 @@ defineExpose({ focus: setFocus, value: selectedItems });
                         tabindex="0"
                         role="button"
                         :aria-label="ariaCloseLabel"
-                        both
-                        @keydown.enter="removeItem(index, $event)"
-                        @click="removeItem(index, $event)" />
+                        @click="removeItem(index, $event)"
+                        @keydown.enter="removeItem(index, $event)" />
                 </span>
             </slot>
 

--- a/packages/oruga/src/types/config.ts
+++ b/packages/oruga/src/types/config.ts
@@ -91,6 +91,11 @@ export type GlobalConfig = Partial<{
      * you can specify the override behaviour here globaly.
      */
     override: boolean;
+    /**
+     * @private
+     * @ignore
+     */
+    environment: "docs" | "examples";
 }>;
 
 export interface OrugaOptions extends GlobalConfig {}

--- a/packages/oruga/src/utils/icons.ts
+++ b/packages/oruga/src/utils/icons.ts
@@ -17,7 +17,7 @@ const mdiIcons = {
     iconPrefix: "mdi-",
 };
 
-const faIcons = () => {
+const faIcons = (): IconConfig => {
     const iconComponent = getOption("iconComponent");
     const faIconPrefix = iconComponent ? "" : "fa-";
     return {


### PR DESCRIPTION
## Proposed Changes

- remove `both` prop from icon component
- remove `icon-both` prop from button component
- add internal `environment` variable to the config object
