### PR TITLE
feat(input): expose `checkHtml5Validity` method

### DIFF
--- a/packages/oruga/src/components/autocomplete/Autocomplete.vue
+++ b/packages/oruga/src/components/autocomplete/Autocomplete.vue
@@ -410,7 +410,7 @@ const itemFooterClasses = defineClasses([
 // #endregion --- Computed Component Classes ---
 
 /** expose functionalities for programmatic usage */
-defineExpose({ focus: setFocus, value: inputValue });
+defineExpose({ checkHtml5Validity, focus: setFocus, value: inputValue });
 </script>
 
 <template>

--- a/packages/oruga/src/components/checkbox/Checkbox.vue
+++ b/packages/oruga/src/components/checkbox/Checkbox.vue
@@ -71,7 +71,7 @@ const emits = defineEmits<{
 const inputRef = useTemplateRef("inputElement");
 
 // use form input functionalities
-const { onBlur, onFocus, onInvalid, setFocus } = useInputHandler(
+const { checkHtml5Validity, onBlur, onFocus, onInvalid, setFocus } = useInputHandler(
     inputRef,
     emits,
     props,
@@ -147,7 +147,7 @@ const labelClasses = defineClasses(["labelClass", "o-checkbox__label"]);
 // --- Expose Public Functionalities ---
 
 /** expose functionalities for programmatic usage */
-defineExpose({ focus: setFocus, value: vmodel });
+defineExpose({ checkHtml5Validity, focus: setFocus, value: vmodel });
 </script>
 
 <template>

--- a/packages/oruga/src/components/datetimepicker/Datetimepicker.vue
+++ b/packages/oruga/src/components/datetimepicker/Datetimepicker.vue
@@ -145,7 +145,7 @@ const elementRef = computed(() =>
 );
 
 // use form input functionality for native input
-const { setFocus, onBlur, onFocus, onInvalid } = useInputHandler(
+const { checkHtml5Validity, setFocus, onBlur, onFocus, onInvalid } = useInputHandler(
     elementRef,
     emits,
     props,
@@ -336,7 +336,7 @@ const timepickerWrapperClasses = defineClasses([
 // --- Expose Public Functionalities ---
 
 /** expose functionalities for programmatic usage */
-defineExpose({ focus: setFocus, value: vmodel });
+defineExpose({ checkHtml5Validity, focus: setFocus, value: vmodel });
 </script>
 
 <template>

--- a/packages/oruga/src/components/input/Input.vue
+++ b/packages/oruga/src/components/input/Input.vue
@@ -345,7 +345,7 @@ const counterClasses = defineClasses(["counterClass", "o-input__counter"]);
 // --- Expose Public Functionalities ---
 
 /** expose functionalities for programmatic usage */
-defineExpose({ focus: setFocus, value: vmodel });
+defineExpose({ checkHtml5Validity, focus: setFocus, value: vmodel });
 </script>
 
 <template>

--- a/packages/oruga/src/components/radio/Radio.vue
+++ b/packages/oruga/src/components/radio/Radio.vue
@@ -67,7 +67,7 @@ const emits = defineEmits<{
 const inputRef = useTemplateRef("inputElement");
 
 // use form input functionalities
-const { onBlur, onFocus, onInvalid, setFocus } = useInputHandler(
+const { checkHtml5Validity, onBlur, onFocus, onInvalid, setFocus } = useInputHandler(
     inputRef,
     emits,
     props,
@@ -132,7 +132,7 @@ const labelClasses = defineClasses(["labelClass", "o-radio__label"]);
 // --- Expose Public Functionalities ---
 
 /** expose functionalities for programmatic usage */
-defineExpose({ focus: setFocus, value: vmodel });
+defineExpose({ checkHtml5Validity, focus: setFocus, value: vmodel });
 </script>
 
 <template>

--- a/packages/oruga/src/components/select/Select.vue
+++ b/packages/oruga/src/components/select/Select.vue
@@ -268,7 +268,7 @@ const iconRightClasses = defineClasses([
 // --- Expose Public Functionalities ---
 
 /** expose functionalities for programmatic usage */
-defineExpose({ focus: setFocus, value: vmodel });
+defineExpose({ checkHtml5Validity, focus: setFocus, value: vmodel });
 </script>
 
 <template>

--- a/packages/oruga/src/components/switch/Switch.vue
+++ b/packages/oruga/src/components/switch/Switch.vue
@@ -72,7 +72,7 @@ const emits = defineEmits<{
 const inputRef = useTemplateRef("inputElement");
 
 // use form input functionalities
-const { onBlur, onFocus, onInvalid, setFocus } = useInputHandler(
+const { checkHtml5Validity, onBlur, onFocus, onInvalid, setFocus } = useInputHandler(
     inputRef,
     emits,
     props,
@@ -155,7 +155,7 @@ const labelClasses = defineClasses(["labelClass", "o-switch__label"]);
 // --- Expose Public Functionalities ---
 
 /** expose functionalities for programmatic usage */
-defineExpose({ focus: setFocus, value: vmodel });
+defineExpose({ checkHtml5Validity, focus: setFocus, value: vmodel });
 </script>
 
 <template>

--- a/packages/oruga/src/components/taginput/Taginput.vue
+++ b/packages/oruga/src/components/taginput/Taginput.vue
@@ -136,7 +136,7 @@ const emits = defineEmits<{
 const autocompleteRef = useTemplateRef<Component>("autocompleteComponent");
 
 // use form input functionalities
-const { setFocus, onFocus, onBlur, onInvalid } = useInputHandler(
+const { checkHtml5Validity, setFocus, onFocus, onBlur, onInvalid } = useInputHandler(
     autocompleteRef,
     emits,
     props,
@@ -322,7 +322,7 @@ const autocompleteBind = computed(() => ({
 // --- Expose Public Functionalities ---
 
 /** expose functionalities for programmatic usage */
-defineExpose({ focus: setFocus, value: selectedItems });
+defineExpose({ checkHtml5Validity, focus: setFocus, value: selectedItems });
 </script>
 
 <template>

--- a/packages/oruga/src/components/upload/Upload.vue
+++ b/packages/oruga/src/components/upload/Upload.vue
@@ -231,7 +231,7 @@ const draggableClasses = defineClasses(
 // --- Expose Public Functionalities ---
 
 /** expose functionalities for programmatic usage */
-defineExpose({ focus: setFocus, value: vmodel });
+defineExpose({ checkHtml5Validity, focus: setFocus, value: vmodel });
 </script>
 
 <template>

--- a/packages/oruga/src/components/utils/PickerWrapper.vue
+++ b/packages/oruga/src/components/utils/PickerWrapper.vue
@@ -319,7 +319,7 @@ const dropdownBind = computed(() => ({
 // --- Expose Public Functionalities ---
 
 /** expose functionalities for programmatic usage */
-defineExpose({ focus: setFocus });
+defineExpose({ checkHtml5Validity, focus: setFocus });
 </script>
 
 <template>


### PR DESCRIPTION
There are some cases where it's useful, such as asynchronous validation.

## Proposed Changes

- Inputs now expose a `checkHtml5Validity` method that is callable through a `ref`.

