### PR TITLE
fix(useTrapFocus): prevent duplicate event handler binding on component update

### DIFF
--- a/packages/oruga/src/components/modal/Modal.vue
+++ b/packages/oruga/src/components/modal/Modal.vue
@@ -215,7 +215,7 @@ defineExpose({ close });
                 v-show="isActive"
                 ref="rootElement"
                 v-bind="$attrs"
-                v-trap-focus="isActive && trapFocus"
+                v-trap-focus="trapFocus && isActive"
                 data-oruga="modal"
                 :class="rootClasses"
                 :tabindex="-1"

--- a/packages/oruga/src/components/sidebar/Sidebar.vue
+++ b/packages/oruga/src/components/sidebar/Sidebar.vue
@@ -262,7 +262,7 @@ defineExpose({ close });
             v-show="!hideOnMobile"
             ref="rootElement"
             v-bind="$attrs"
-            v-trap-focus="isActive && !inline && trapFocus"
+            v-trap-focus="trapFocus && isActive && !inline"
             data-oruga="sidebar"
             :class="rootClasses">
             <div

--- a/packages/oruga/src/composables/useTrapFocus.ts
+++ b/packages/oruga/src/composables/useTrapFocus.ts
@@ -41,7 +41,7 @@ export function useTrapFocus(): {
         }
     }
 
-    const bind: DirectiveHook<HTMLElement> = (el, { value }) => {
+    const onMounted: DirectiveHook<HTMLElement> = (el, { value }) => {
         // create onKeyDown event listener
         onKeyDown = (event: KeyboardEvent): void => {
             const target = event.target as HTMLElement;
@@ -77,26 +77,29 @@ export function useTrapFocus(): {
             }
         };
 
-        applyHandler(el, value);
+        // apply handler when binding value is already true
+        if (value) applyHandler(el, value);
     };
 
-    /** cleanup on unbind */
-    const unbind: DirectiveHook = (el) => {
+    /** cleanup on beforeUnmount */
+    const onBeforeUnmount: DirectiveHook<HTMLElement> = (el) => {
         // remove handler
         applyHandler(el, false);
         onKeyDown = null;
     };
 
-    const update: DirectiveHook<HTMLElement> = (el, { value }) => {
-        // update handlers based on binding
-        applyHandler(el, value);
+    const onUpdate: DirectiveHook<HTMLElement> = (el, { value, oldValue }) => {
+        // check if binding value has changed
+        if (value !== oldValue)
+            // update handler based on binding value
+            applyHandler(el, value);
     };
 
     return {
         vTrapFocus: {
-            mounted: bind,
-            beforeUnmount: unbind,
-            updated: update,
+            mounted: onMounted,
+            beforeUnmount: onBeforeUnmount,
+            updated: onUpdate,
         },
     };
 }


### PR DESCRIPTION
…nt update

<!-- Thank you for helping Oruga! -->

Fixes #1275
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- cleanup `useTrapFocus` composable 
- check if binding value has changed in component update hook 