### PR TITLE
fix(field): prevent setting `aria-describedby` when no message is displayed

### DIFF
--- a/packages/oruga/src/components/field/Field.vue
+++ b/packages/oruga/src/components/field/Field.vue
@@ -146,7 +146,8 @@ const inputAttrs = computed(() => ({
     "aria-labelledby": props.labelId,
     ...(fieldVariant.value === "error"
         ? { "aria-errormessage": props.messageId }
-        : { "aria-describedby": props.messageId }),
+        : {}),
+    ...(!!fieldMessage.value ? { "aria-describedby": props.messageId } : {}),
 }));
 
 // Provided data is a computed ref to ensure reactivity.


### PR DESCRIPTION
## Proposed Changes

- prevent setting `aria-describedby` when no message is displayed