### PR TITLE
fix(table): hide detail row when parent row got hidden

### DIFF
--- a/packages/oruga/src/components/table/Table.vue
+++ b/packages/oruga/src/components/table/Table.vue
@@ -599,7 +599,7 @@ let debouncedFilter: ReturnType<
     typeof useDebounce<Parameters<typeof handleFiltersChange>>
 >;
 
-// initialise and update debounces filter function
+// initialise and update debounces filter function based on `filterDebounce` prop
 watch(
     () => props.filterDebounce,
     (debounce) =>
@@ -607,7 +607,7 @@ watch(
     { immediate: true },
 );
 
-// react on filters got changed
+// react on filter got changed
 watch(filters, (value) => debouncedFilter(value), { deep: true });
 
 function handleFiltersChange(value: Record<string, string>): void {
@@ -1630,7 +1630,7 @@ defineExpose({ rows: tableRows, sort: sortByField });
                         </tr>
 
                         <transition-group
-                            v-if="props.detailed"
+                            v-if="!row.hidden && props.detailed"
                             :name="detailTransition">
                             <template v-if="isDetailRowVisible(row)">
                                 <!--

--- a/packages/oruga/src/components/table/tests/table.test.ts
+++ b/packages/oruga/src/components/table/tests/table.test.ts
@@ -462,6 +462,38 @@ describe("OTable tests", () => {
             const bodyRows = wrapper.findAll("tbody tr");
             expect(bodyRows).toHaveLength(5); // Filtering after debounce
         });
+
+        test("hide detail row when data is filtered out", async () => {
+            const wrapper = mount(OTable, {
+                props: {
+                    columns: [
+                        { label: "ID", field: "id", numeric: true },
+                        { label: "Name", field: "name", searchable: true },
+                    ],
+                    data,
+                    detailed: true,
+                    // open detail for first data row
+                    detailedRows: [data[0]],
+                },
+                slots: { detail: "DETAIL" },
+            });
+            await nextTick();
+
+            const input = wrapper.find("thead input");
+            expect(input.exists()).toBeTruthy();
+
+            let bodyRows = wrapper.findAll("tbody tr");
+            expect(bodyRows).toHaveLength(data.length + 1); // data rows + detail for row 1
+            expect(bodyRows[1].text()).toBe("DETAIL"); // check second row is detal row
+
+            await input.setValue("T");
+            await input.trigger("input");
+            vi.runAllTimers(); // run debounce timer
+            await flushPromises();
+
+            bodyRows = wrapper.findAll("tbody tr");
+            expect(bodyRows).toHaveLength(1); // Tina
+        });
     });
 
     describe("test sorting", () => {


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #1352

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- hide detail row when parent row got hidden
