### PR TITLE
fix(table): match active filters against visible column string instead value

### DIFF
--- a/packages/oruga/src/components/table/examples/searchable.vue
+++ b/packages/oruga/src/components/table/examples/searchable.vue
@@ -61,6 +61,7 @@ const columns: TableColumn<(typeof data)[number]>[] = [
         field: "date",
         label: "Date",
         position: "centered",
+        searchable: true,
         formatter: (v): string => new Date(String(v)).toLocaleDateString(),
     },
     {


### PR DESCRIPTION
Fixes #646

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- update `isRowFiltered` function of the Table component to match the filter value against the visible row label of the column value instead of the column value of the row