### PR TITLE
fix(dropdown): update a11y attributes

### DIFF
--- a/packages/oruga/src/components/autocomplete/tests/__snapshots__/autocomplete.test.ts.snap
+++ b/packages/oruga/src/components/autocomplete/tests/__snapshots__/autocomplete.test.ts.snap
@@ -18,7 +18,7 @@ exports[`OAutocomplete tests > render correctly 1`] = `
   <!--teleport start-->
   <!--v-if-->
   <transition-stub name="fade" appear="false" persisted="true" css="true">
-    <div id="v-0" tabindex="-1" class="o-dropdown__menu o-dropdown__menu--auto" style="max-height: 200px; overflow: auto; display: none;" role="listbox" aria-hidden="true" aria-multiselectable="false">
+    <div id="v-0" tabindex="-1" class="o-dropdown__menu o-dropdown__menu--auto" style="max-height: 200px; overflow: auto; display: none;" role="listbox" aria-multiselectable="false">
       <!--
                         @slot Place dropdown items here
                         @binding {boolean} active - dropdown active state
@@ -27,9 +27,9 @@ exports[`OAutocomplete tests > render correctly 1`] = `
                     -->
       <!--v-if-->
       <!--v-if-->
-      <div id="v-0-1" data-oruga="dropdown-item" data-id="dropdown-1" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" aria-selected="false" aria-disabled="false">
+      <div id="v-0-1" data-oruga="dropdown-item" data-id="dropdown-1" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" tabindex="-1" aria-selected="false" aria-disabled="false">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->
         <!--
                     @slot Override the select option
@@ -38,9 +38,9 @@ exports[`OAutocomplete tests > render correctly 1`] = `
                     @binding {unknown} value - option value
                 --><span>Angular</span>
       </div>
-      <div id="v-0-2" data-oruga="dropdown-item" data-id="dropdown-2" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" aria-selected="false" aria-disabled="false">
+      <div id="v-0-2" data-oruga="dropdown-item" data-id="dropdown-2" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" tabindex="-1" aria-selected="false" aria-disabled="false">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->
         <!--
                     @slot Override the select option
@@ -49,9 +49,9 @@ exports[`OAutocomplete tests > render correctly 1`] = `
                     @binding {unknown} value - option value
                 --><span>Angular 2</span>
       </div>
-      <div id="v-0-3" data-oruga="dropdown-item" data-id="dropdown-3" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" aria-selected="false" aria-disabled="false">
+      <div id="v-0-3" data-oruga="dropdown-item" data-id="dropdown-3" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" tabindex="-1" aria-selected="false" aria-disabled="false">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->
         <!--
                     @slot Override the select option
@@ -60,9 +60,9 @@ exports[`OAutocomplete tests > render correctly 1`] = `
                     @binding {unknown} value - option value
                 --><span>Aurelia</span>
       </div>
-      <div id="v-0-4" data-oruga="dropdown-item" data-id="dropdown-4" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" aria-selected="false" aria-disabled="false">
+      <div id="v-0-4" data-oruga="dropdown-item" data-id="dropdown-4" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" tabindex="-1" aria-selected="false" aria-disabled="false">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->
         <!--
                     @slot Override the select option
@@ -71,9 +71,9 @@ exports[`OAutocomplete tests > render correctly 1`] = `
                     @binding {unknown} value - option value
                 --><span>Backbone</span>
       </div>
-      <div id="v-0-5" data-oruga="dropdown-item" data-id="dropdown-5" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" aria-selected="false" aria-disabled="false">
+      <div id="v-0-5" data-oruga="dropdown-item" data-id="dropdown-5" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" tabindex="-1" aria-selected="false" aria-disabled="false">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->
         <!--
                     @slot Override the select option
@@ -82,9 +82,9 @@ exports[`OAutocomplete tests > render correctly 1`] = `
                     @binding {unknown} value - option value
                 --><span>Ember</span>
       </div>
-      <div id="v-0-6" data-oruga="dropdown-item" data-id="dropdown-6" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" aria-selected="false" aria-disabled="false">
+      <div id="v-0-6" data-oruga="dropdown-item" data-id="dropdown-6" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" tabindex="-1" aria-selected="false" aria-disabled="false">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->
         <!--
                     @slot Override the select option
@@ -93,9 +93,9 @@ exports[`OAutocomplete tests > render correctly 1`] = `
                     @binding {unknown} value - option value
                 --><span>jQuery</span>
       </div>
-      <div id="v-0-7" data-oruga="dropdown-item" data-id="dropdown-7" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" aria-selected="false" aria-disabled="false">
+      <div id="v-0-7" data-oruga="dropdown-item" data-id="dropdown-7" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" tabindex="-1" aria-selected="false" aria-disabled="false">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->
         <!--
                     @slot Override the select option
@@ -104,9 +104,9 @@ exports[`OAutocomplete tests > render correctly 1`] = `
                     @binding {unknown} value - option value
                 --><span>Meteor</span>
       </div>
-      <div id="v-0-8" data-oruga="dropdown-item" data-id="dropdown-8" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" aria-selected="false" aria-disabled="false">
+      <div id="v-0-8" data-oruga="dropdown-item" data-id="dropdown-8" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" tabindex="-1" aria-selected="false" aria-disabled="false">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->
         <!--
                     @slot Override the select option
@@ -115,9 +115,9 @@ exports[`OAutocomplete tests > render correctly 1`] = `
                     @binding {unknown} value - option value
                 --><span>Node.js</span>
       </div>
-      <div id="v-0-9" data-oruga="dropdown-item" data-id="dropdown-9" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" aria-selected="false" aria-disabled="false">
+      <div id="v-0-9" data-oruga="dropdown-item" data-id="dropdown-9" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" tabindex="-1" aria-selected="false" aria-disabled="false">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->
         <!--
                     @slot Override the select option
@@ -126,9 +126,9 @@ exports[`OAutocomplete tests > render correctly 1`] = `
                     @binding {unknown} value - option value
                 --><span>Polymer</span>
       </div>
-      <div id="v-0-10" data-oruga="dropdown-item" data-id="dropdown-10" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" aria-selected="false" aria-disabled="false">
+      <div id="v-0-10" data-oruga="dropdown-item" data-id="dropdown-10" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" tabindex="-1" aria-selected="false" aria-disabled="false">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->
         <!--
                     @slot Override the select option
@@ -137,9 +137,9 @@ exports[`OAutocomplete tests > render correctly 1`] = `
                     @binding {unknown} value - option value
                 --><span>React</span>
       </div>
-      <div id="v-0-11" data-oruga="dropdown-item" data-id="dropdown-11" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" aria-selected="false" aria-disabled="false">
+      <div id="v-0-11" data-oruga="dropdown-item" data-id="dropdown-11" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" tabindex="-1" aria-selected="false" aria-disabled="false">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->
         <!--
                     @slot Override the select option
@@ -148,9 +148,9 @@ exports[`OAutocomplete tests > render correctly 1`] = `
                     @binding {unknown} value - option value
                 --><span>RxJS</span>
       </div>
-      <div id="v-0-12" data-oruga="dropdown-item" data-id="dropdown-12" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" aria-selected="false" aria-disabled="false">
+      <div id="v-0-12" data-oruga="dropdown-item" data-id="dropdown-12" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" tabindex="-1" aria-selected="false" aria-disabled="false">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->
         <!--
                     @slot Override the select option

--- a/packages/oruga/src/components/datepicker/tests/__snapshots__/datepicker.test.ts.snap
+++ b/packages/oruga/src/components/datepicker/tests/__snapshots__/datepicker.test.ts.snap
@@ -26,9 +26,9 @@ exports[`ODatepicker > render correctly 1`] = `
                         @binding {number} focusedIndex - index of the focused element
                         @binding {(): void} toggle - toggle dropdown active state
                     -->
-        <div id="v-0-1" data-oruga="dropdown-item" data-id="dropdown-1" class="o-datepicker__box" role="menuitem" aria-disabled="false">
+        <div id="v-0-1" data-oruga="dropdown-item" data-id="dropdown-1" class="o-datepicker__box" role="menuitem" tabindex="-1" aria-disabled="false">
           <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->
           <header class="o-datepicker__header">
             <!--

--- a/packages/oruga/src/components/datetimepicker/tests/__snapshots__/datetimepicker.test.ts.snap
+++ b/packages/oruga/src/components/datetimepicker/tests/__snapshots__/datetimepicker.test.ts.snap
@@ -26,9 +26,9 @@ exports[`ODatetimepicker tests > render correctly 1`] = `
                         @binding {number} focusedIndex - index of the focused element
                         @binding {(): void} toggle - toggle dropdown active state
                     -->
-        <div id="v-0-1" data-oruga="dropdown-item" data-id="dropdown-1" class="o-datepicker__box" role="menuitem" aria-disabled="false">
+        <div id="v-0-1" data-oruga="dropdown-item" data-id="dropdown-1" class="o-datepicker__box" role="menuitem" tabindex="-1" aria-disabled="false">
           <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->
           <header class="o-datepicker__header">
             <!--
@@ -330,16 +330,16 @@ exports[`ODatetimepicker tests > render correctly 1`] = `
                   <!--teleport start-->
                   <!--v-if-->
                   <transition-stub name="fade" appear="false" persisted="true" css="true">
-                    <div id="v-5" tabindex="0" class="o-dropdown__menu o-dropdown__menu--bottom-left o-dropdown__menu--active" role="menu" aria-hidden="false">
+                    <div id="v-5" tabindex="0" class="o-dropdown__menu o-dropdown__menu--bottom-left o-dropdown__menu--active" role="menu">
                       <!--
                         @slot Place dropdown items here
                         @binding {boolean} active - dropdown active state
                         @binding {number} focusedIndex - index of the focused element
                         @binding {(): void} toggle - toggle dropdown active state
                     -->
-                      <div id="v-5-1" data-oruga="dropdown-item" data-id="dropdown-1" class="o-timepicker__box" role="menuitem" aria-disabled="false">
+                      <div id="v-5-1" data-oruga="dropdown-item" data-id="dropdown-1" class="o-timepicker__box" role="menuitem" tabindex="-1" aria-disabled="false">
                         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->
                         <div data-oruga="select" class="">
                           <!--v-if--><select aria-label="Select Hour" id="v-7" data-oruga-input="select" class="o-timepicker__select" autocomplete="off">

--- a/packages/oruga/src/components/dropdown/Dropdown.vue
+++ b/packages/oruga/src/components/dropdown/Dropdown.vue
@@ -628,7 +628,11 @@ defineExpose({ $trigger: triggerRef, $content: menuRef, value: vmodel });
                     :role="selectable ? 'listbox' : 'menu'"
                     :aria-labelledby="labelId"
                     :aria-label="ariaLabel"
-                    :aria-hidden="!inline && (disabled || !isActive)"
+                    :aria-hidden="
+                        !selectable && !inline
+                            ? disabled || !isActive
+                            : undefined
+                    "
                     :aria-multiselectable="
                         selectable ? isTrueish(multiple) : undefined
                     "

--- a/packages/oruga/src/components/dropdown/DropdownItem.vue
+++ b/packages/oruga/src/components/dropdown/DropdownItem.vue
@@ -109,6 +109,7 @@ const rootClasses = defineClasses(
         :data-id="`dropdown-${item.identifier}`"
         :class="rootClasses"
         :role="parent.selectable ? 'option' : 'menuitem'"
+        tabindex="-1"
         :aria-selected="parent.selectable ? isSelected : undefined"
         :aria-disabled="disabled"
         @click="selectItem"
@@ -116,7 +117,7 @@ const rootClasses = defineClasses(
         @keydown.enter="selectItem"
         @keydown.space="selectItem">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->
         <slot>{{ label }}</slot>
     </component>

--- a/packages/oruga/src/components/dropdown/tests/__snapshots__/dropdown.test.ts.snap
+++ b/packages/oruga/src/components/dropdown/tests/__snapshots__/dropdown.test.ts.snap
@@ -13,26 +13,26 @@ exports[`ODropdown tests > render correctly with items 1`] = `
   <!--teleport start-->
   <!--v-if-->
   <transition-stub name="fade" appear="false" persisted="true" css="true">
-    <div id="v-0" tabindex="-1" class="o-dropdown__menu o-dropdown__menu--bottom-left" role="listbox" aria-hidden="true" aria-multiselectable="false" style="display: none;">
+    <div id="v-0" tabindex="-1" class="o-dropdown__menu o-dropdown__menu--bottom-left" role="listbox" aria-multiselectable="false" style="display: none;">
       <!--
                         @slot Place dropdown items here
                         @binding {boolean} active - dropdown active state
                         @binding {number} focusedIndex - index of the focused element
                         @binding {(): void} toggle - toggle dropdown active state
                     -->
-      <div id="v-0-1" data-oruga="dropdown-item" data-id="dropdown-1" class="o-dropdown__item o-dropdown__item--clickable" role="option" aria-selected="false" aria-disabled="false">
+      <div id="v-0-1" data-oruga="dropdown-item" data-id="dropdown-1" class="o-dropdown__item o-dropdown__item--clickable" role="option" tabindex="-1" aria-selected="false" aria-disabled="false">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->A
       </div>
-      <div id="v-0-2" data-oruga="dropdown-item" data-id="dropdown-2" class="o-dropdown__item o-dropdown__item--clickable" role="option" aria-selected="false" aria-disabled="false">
+      <div id="v-0-2" data-oruga="dropdown-item" data-id="dropdown-2" class="o-dropdown__item o-dropdown__item--clickable" role="option" tabindex="-1" aria-selected="false" aria-disabled="false">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->B
       </div>
-      <div id="v-0-3" data-oruga="dropdown-item" data-id="dropdown-3" class="o-dropdown__item o-dropdown__item--clickable" role="option" aria-selected="false" aria-disabled="false">
+      <div id="v-0-3" data-oruga="dropdown-item" data-id="dropdown-3" class="o-dropdown__item o-dropdown__item--clickable" role="option" tabindex="-1" aria-selected="false" aria-disabled="false">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->C
       </div>
     </div>
@@ -65,19 +65,19 @@ exports[`ODropdown tests > render correctly with options 1`] = `
                             @slot Place extra \`o-dropdown-item\` components here, even if you have some options defined by prop
                         -->
       <!--v-if-->
-      <div id="v-0-1" data-oruga="dropdown-item" data-id="dropdown-1" class="o-dropdown__item o-dropdown__item--clickable" role="menuitem" aria-disabled="false">
+      <div id="v-0-1" data-oruga="dropdown-item" data-id="dropdown-1" class="o-dropdown__item o-dropdown__item--clickable" role="menuitem" tabindex="-1" aria-disabled="false">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->Item 1
       </div>
-      <div id="v-0-2" data-oruga="dropdown-item" data-id="dropdown-2" class="o-dropdown__item o-dropdown__item--clickable" role="menuitem" aria-disabled="false">
+      <div id="v-0-2" data-oruga="dropdown-item" data-id="dropdown-2" class="o-dropdown__item o-dropdown__item--clickable" role="menuitem" tabindex="-1" aria-disabled="false">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->Item 2
       </div>
-      <div id="v-0-3" data-oruga="dropdown-item" data-id="dropdown-3" class="o-dropdown__item o-dropdown__item--clickable" role="menuitem" aria-disabled="false">
+      <div id="v-0-3" data-oruga="dropdown-item" data-id="dropdown-3" class="o-dropdown__item o-dropdown__item--clickable" role="menuitem" tabindex="-1" aria-disabled="false">
         <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->Item 3
       </div>
       <!--

--- a/packages/oruga/src/components/taginput/tests/__snapshots__/taginput.test.ts.snap
+++ b/packages/oruga/src/components/taginput/tests/__snapshots__/taginput.test.ts.snap
@@ -26,7 +26,7 @@ exports[`OTaginput tests > render correctly 1`] = `
       <!--teleport start-->
       <!--v-if-->
       <transition-stub name="fade" appear="false" persisted="true" css="true">
-        <div id="v-0" tabindex="-1" class="o-dropdown__menu o-dropdown__menu--auto" style="max-height: 200px; overflow: auto; display: none;" role="listbox" aria-hidden="true" aria-multiselectable="false">
+        <div id="v-0" tabindex="-1" class="o-dropdown__menu o-dropdown__menu--auto" style="max-height: 200px; overflow: auto; display: none;" role="listbox" aria-multiselectable="false">
           <!--
                         @slot Place dropdown items here
                         @binding {boolean} active - dropdown active state

--- a/packages/oruga/src/components/timepicker/tests/__snapshots__/timepicker.test.ts.snap
+++ b/packages/oruga/src/components/timepicker/tests/__snapshots__/timepicker.test.ts.snap
@@ -26,9 +26,9 @@ exports[`OTimepicker tests > render correctly 1`] = `
                         @binding {number} focusedIndex - index of the focused element
                         @binding {(): void} toggle - toggle dropdown active state
                     -->
-        <div id="v-0-1" data-oruga="dropdown-item" data-id="dropdown-1" class="o-timepicker__box" role="menuitem" aria-disabled="false">
+        <div id="v-0-1" data-oruga="dropdown-item" data-id="dropdown-1" class="o-timepicker__box" role="menuitem" tabindex="-1" aria-disabled="false">
           <!--
-            @slot Override the label, default is label prop 
+            @slot Override the label, default is label prop
         -->
           <div data-oruga="select" class="">
             <!--v-if--><select aria-label="Select Hour" id="v-3" data-oruga-input="select" class="o-timepicker__select" autocomplete="off">


### PR DESCRIPTION
## Proposed Changes

- add `tabindex="-1"` to dropdown-item
- remove `aria-hidden` attribute when selectable
Reason: 
```
Blocked aria-hidden on an element because its descendant retained focus. The focus must not be hidden from assistive  
technology users. Avoid using aria-hidden on a focused element or its ancestor. Consider using the inert attribute instead, which 
will also prevent focus. For more details, see the aria-hidden section of the WAI-ARIA specification at  https://w3c.github.io/aria/#aria-hidden.
Element with focus: <div.dropdown-menu position-bottom-left fade-leave-from fade-leave-active#v-8>
Ancestor with aria-hidden: <div.dropdown-menu position-bottom-left fade-leave-from fade-leave-active#v-8> 
```
