### PR TITLE
refactor(useProviderChild): add root element to provider child

### DIFF
--- a/packages/oruga/src/components/breadcrumb/BreadcrumbItem.vue
+++ b/packages/oruga/src/components/breadcrumb/BreadcrumbItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, useTemplateRef } from "vue";
 
 import OIcon from "../icon/Icon.vue";
 
@@ -32,8 +32,10 @@ const props = withDefaults(defineProps<BreadcrumbItemProps>(), {
     tag: () => getDefault("breadcrumb.tag", "a"),
 });
 
+const rootRef = useTemplateRef("rootElement");
+
 /** inject functionalities and data from the parent component */
-const { item } = useProviderChild();
+const { item } = useProviderChild(rootRef);
 
 // #region --- Computed Component Classes ---
 
@@ -71,6 +73,7 @@ const iconRightClasses = defineClasses(
 <template>
     <li
         v-show="!hidden"
+        ref="rootElement"
         data-oruga="breadcrumb-item"
         :data-id="`breadcrumb-${item.identifier}`"
         :class="rootClasses"

--- a/packages/oruga/src/components/carousel/CarouselItem.vue
+++ b/packages/oruga/src/components/carousel/CarouselItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, useTemplateRef } from "vue";
 
 import { defineClasses, useProviderChild } from "@/composables";
 
@@ -21,8 +21,10 @@ const props = withDefaults(defineProps<CarouselItemProps>(), {
     clickable: false,
 });
 
+const rootRef = useTemplateRef("rootElement");
+
 /** inject functionalities and data from the parent component */
-const { parent, item } = useProviderChild<CarouselComponent>();
+const { parent, item } = useProviderChild<CarouselComponent>(rootRef);
 
 const isActive = computed(() => parent.value.activeIndex === item.value.index);
 
@@ -33,7 +35,7 @@ function onClick(event: Event): void {
     if (props.clickable) parent.value.setActive(item.value.index);
 }
 
-// --- Computed Component Classes ---
+// #region --- Computed Component Classes ---
 
 const itemClasses = defineClasses(
     ["itemClass", "o-carousel__item"],
@@ -45,11 +47,14 @@ const itemClasses = defineClasses(
         computed(() => props.clickable),
     ],
 );
+
+// #endregion --- Computed Component Classes ---
 </script>
 
 <template>
     <div
         :id="`carouselpanel-${item.identifier}`"
+        ref="rootElement"
         data-oruga="carousel-item"
         :data-id="`carousel-${item.identifier}`"
         :class="itemClasses"

--- a/packages/oruga/src/components/dropdown/Dropdown.vue
+++ b/packages/oruga/src/components/dropdown/Dropdown.vue
@@ -8,7 +8,6 @@ import { getDefault } from "@/utils/config";
 import { toCssDimension, isMobileAgent, isTrueish, mod } from "@/utils/helpers";
 import { isClient } from "@/utils/ssr";
 import {
-    unrefElement,
     defineClasses,
     toOptionsGroup,
     normalizeOptions,
@@ -120,7 +119,7 @@ const emits = defineEmits<{
 }>();
 
 const triggerRef = ref<HTMLElement>();
-const menuRef = ref<HTMLElement | Component>();
+const menuRef = ref<HTMLElement | Component | null>(null);
 
 // provided data is a computed ref to ensure reactivity
 const provideData = computed<DropdownComponent<T>>(() => ({
@@ -399,15 +398,11 @@ function setFocus(item: DropdownChildItem<T>): void {
     if (props.selectOnFocus && item.data?.value)
         selectItem(item, new Event("focus"));
 
-    const dropdownMenu = unrefElement(menuRef);
-    const element = unrefElement(item.data?.$el);
-    if (!dropdownMenu || !element) return;
-
     // set item as focused
     focusedItem.value = item;
 
     // scroll item into view
-    scrollElementInView(dropdownMenu, element);
+    scrollElementInView(menuRef, item.el);
 }
 
 function onUpPressed(event: Event): void {

--- a/packages/oruga/src/components/dropdown/DropdownItem.vue
+++ b/packages/oruga/src/components/dropdown/DropdownItem.vue
@@ -39,12 +39,11 @@ const emits = defineEmits<{
 
 const itemValue = props.value ?? useId();
 
-const rootRef = useTemplateRef<Element>("rootElement");
+const rootRef = useTemplateRef("rootElement");
 
 // provided data is a computed ref to ensure reactivity
 const providedData = computed<DropdownItemComponent<T>>(() => ({
     ...props,
-    $el: rootRef.value,
     value: itemValue,
     selectItem,
 }));
@@ -53,7 +52,7 @@ const providedData = computed<DropdownItemComponent<T>>(() => ({
 const { parent, item } = useProviderChild<
     DropdownComponent<T>,
     DropdownItemComponent<T>
->({ data: providedData });
+>(rootRef, { data: providedData });
 
 const isClickable = computed(
     () => !parent.value.disabled && !props.disabled && props.clickable,
@@ -84,7 +83,7 @@ function focusItem(): void {
     parent.value.focusItem(item.value);
 }
 
-// --- Computed Component Classes ---
+// #region --- Computed Component Classes ---
 
 const rootClasses = defineClasses(
     ["itemClass", "o-dropdown__item"],
@@ -98,6 +97,8 @@ const rootClasses = defineClasses(
     ["itemClickableClass", "o-dropdown__item--clickable", null, isClickable],
     ["itemFocusedClass", "o-dropdown__item--focused", null, isFocused],
 );
+
+// #endregion --- Computed Component Classes ---
 </script>
 
 <template>

--- a/packages/oruga/src/components/dropdown/types.ts
+++ b/packages/oruga/src/components/dropdown/types.ts
@@ -13,7 +13,6 @@ export type DropdownComponent<T> = {
 };
 
 export type DropdownItemComponent<T> = DropdownItemProps<T> & {
-    $el: Element | null;
     selectItem: (event: Event) => void;
 };
 

--- a/packages/oruga/src/components/menu/MenuItem.vue
+++ b/packages/oruga/src/components/menu/MenuItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts" generic="T">
-import { computed, ref, useId } from "vue";
+import { computed, ref, useId, useTemplateRef } from "vue";
 
 import OIcon from "../icon/Icon.vue";
 import PlainButton from "../utils/PlainButton";
@@ -63,6 +63,8 @@ const emits = defineEmits<{
 
 const itemValue = props.value ?? useId();
 
+const rootRef = useTemplateRef("rootElement");
+
 // provided data is a computed ref to ensure reactivity
 const provideData = computed<MenuItemProvider<T>>(() => ({
     expanded: isExpanded.value,
@@ -77,7 +79,7 @@ const { childItems } = useProviderParent({
 });
 
 /** inject functionalities and data from the parent menu-item component */
-const menuItem = useProviderChild<MenuItemProvider<T>>({
+const menuItem = useProviderChild<MenuItemProvider<T>>(rootRef, {
     key: "menu-item",
     needParent: false,
 });
@@ -98,7 +100,7 @@ const providedData = computed<MenuItemComponent<T>>(() => ({
 const { parent, item } = useProviderChild<
     MenuComponent<T>,
     MenuItemComponent<T>
->({ data: providedData });
+>(rootRef, { data: providedData });
 
 const nextSequence = parent.value.nextSequence;
 
@@ -204,6 +206,7 @@ const submenuClasses = defineClasses([
     <li
         v-show="!hidden"
         :id="`${parent.menuId}-${item.identifier}`"
+        ref="rootElement"
         data-oruga="menu-item"
         :data-id="`menu-${item.identifier}`"
         :class="itemClasses"

--- a/packages/oruga/src/components/slider/SliderTick.vue
+++ b/packages/oruga/src/components/slider/SliderTick.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, type PropType } from "vue";
+import { computed, useTemplateRef, type PropType } from "vue";
 import { defineClasses, useProviderChild } from "@/composables";
 
 import type { SliderComponent } from "./types";
@@ -37,8 +37,12 @@ const props = defineProps({
     },
 });
 
+const rootRef = useTemplateRef("rootElement");
+
 /** inject functionalities and data from the parent component */
-const { parent } = useProviderChild<SliderComponent>({ register: false });
+const { parent } = useProviderChild<SliderComponent>(rootRef, {
+    register: false,
+});
 
 const position = computed(() => {
     const pos =
@@ -54,7 +58,7 @@ const hidden = computed(
 
 const tickStyle = computed(() => ({ left: position.value + "%" }));
 
-// --- Computed Component Classes ---
+// #region --- Computed Component Classes ---
 
 const rootClasses = defineClasses(
     ["tickClass", "o-slider__tick"],
@@ -65,10 +69,16 @@ const tickLabelClasses = defineClasses([
     "tickLabelClass",
     "o-slider__tick-label",
 ]);
+
+// #endregion --- Computed Component Classes ---
 </script>
 
 <template>
-    <div data-oruga="slider-tick" :class="rootClasses" :style="tickStyle">
+    <div
+        ref="rootElement"
+        data-oruga="slider-tick"
+        :class="rootClasses"
+        :style="tickStyle">
         <span v-if="$slots.default || label" :class="tickLabelClasses">
             <!-- 
                 @slot Override tick content, default is label prop

--- a/packages/oruga/src/components/steps/StepItem.vue
+++ b/packages/oruga/src/components/steps/StepItem.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts" generic="T, C extends Component">
-import { computed, ref, useSlots, useId, type Component } from "vue";
+import {
+    computed,
+    ref,
+    useSlots,
+    useId,
+    useTemplateRef,
+    type Component,
+} from "vue";
 
 import { getDefault } from "@/utils/config";
 import { defineClasses, useProviderChild } from "@/composables";
@@ -44,6 +51,8 @@ const emits = defineEmits<{
 
 const itemValue = props.value ?? useId();
 
+const rootRef = useTemplateRef("rootElement");
+
 const slots = useSlots();
 
 // provided data is a computed ref to ensure reactivity
@@ -62,6 +71,7 @@ const providedData = computed<StepItemComponent<T>>(() => ({
 
 /** inject functionalities and data from the parent component */
 const { parent, item } = useProviderChild<StepsComponent, StepItemComponent<T>>(
+    rootRef,
     { data: providedData },
 );
 
@@ -114,7 +124,7 @@ function beforeLeave(): void {
     isTransitioning.value = true;
 }
 
-// --- Computed Component Classes ---
+// #region --- Computed Component Classes ---
 
 const stepClasses = defineClasses(
     ["stepClass", "o-steps__step"],
@@ -160,6 +170,8 @@ const stepLabelClasses = defineClasses([
 const stepIconClasses = defineClasses(["stepIconClass", "o-steps__step-icon"]);
 
 const panelClasses = defineClasses(["stepPanelClass", "o-steps__panel"]);
+
+// #endregion --- Computed Component Classes ---
 </script>
 
 <template>
@@ -174,6 +186,7 @@ const panelClasses = defineClasses(["stepPanelClass", "o-steps__panel"]);
             v-show="isActive && visible"
             v-bind="$attrs"
             :id="`tabpanel-${item.identifier}`"
+            ref="rootElement"
             data-oruga="steps-item"
             :data-id="`steps-${item.identifier}`"
             :class="panelClasses"

--- a/packages/oruga/src/components/steps/Steps.vue
+++ b/packages/oruga/src/components/steps/Steps.vue
@@ -108,6 +108,7 @@ const { childItems } = useProviderParent<StepItemComponent<T>>({
 const items = computed<StepItem<T>[]>(() => {
     if (!childItems.value) return [];
     return childItems.value.map((column) => ({
+        el: column.el,
         index: column.index,
         identifier: column.identifier,
         ...toValue(column.data!),

--- a/packages/oruga/src/components/table/Table.vue
+++ b/packages/oruga/src/components/table/Table.vue
@@ -383,6 +383,7 @@ const tableColumns = computed<TableColumnItem<T>[]>(() => {
         return {
             ...column,
             value: column,
+            el: columnItem.el,
             index: columnItem.index,
             identifier: columnItem.identifier,
             thAttrsData: thAttrsData,
@@ -1359,7 +1360,7 @@ defineExpose({ rows: tableRows, sort: sortByField });
                                 ">
                                 <o-slot-component
                                     v-if="column.$slots?.header"
-                                    :component="column.$el"
+                                    :component="column.$instance"
                                     name="header"
                                     tag="span"
                                     :class="thLabelClasses"
@@ -1442,7 +1443,7 @@ defineExpose({ rows: tableRows, sort: sortByField });
                                 <template v-if="column.searchable">
                                     <template v-if="column.$slots?.searchable">
                                         <o-slot-component
-                                            :component="column.$el"
+                                            :component="column.$instance"
                                             name="searchable"
                                             tag="span"
                                             :props="{
@@ -1496,7 +1497,7 @@ defineExpose({ rows: tableRows, sort: sortByField });
                                 ]">
                                 <o-slot-component
                                     v-if="column.$slots?.subheading"
-                                    :component="column.$el"
+                                    :component="column.$instance"
                                     name="subheading"
                                     tag="span"
                                     :props="{
@@ -1600,7 +1601,7 @@ defineExpose({ rows: tableRows, sort: sortByField });
                                 <o-slot-component
                                     v-if="!column.hidden"
                                     v-bind="column.tdAttrsData[row.index]"
-                                    :component="column.$el"
+                                    :component="column.$instance"
                                     name="default"
                                     tag="td"
                                     :class="[

--- a/packages/oruga/src/components/table/TableColumn.vue
+++ b/packages/oruga/src/components/table/TableColumn.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts" generic="T, K extends string">
-import { computed, getCurrentInstance } from "vue";
+import { computed, getCurrentInstance, useTemplateRef } from "vue";
 
 import { defineClasses, useProviderChild } from "@/composables";
 import { toCssDimension } from "@/utils/helpers";
@@ -36,6 +36,8 @@ const props = withDefaults(defineProps<TableColumnProps<T, K>>(), {
     tdAttrs: undefined,
 });
 
+const rootRef = useTemplateRef("rootElement");
+
 const style = computed(() => ({
     width: toCssDimension(props.width),
 }));
@@ -49,7 +51,7 @@ const vm = getCurrentInstance();
 // provided data is a computed ref to ensure reactivity
 const providedData = computed<TableColumnComponent<T>>(() => ({
     ...props,
-    $el: vm!.proxy!,
+    $instance: vm!.proxy!,
     $slots: vm!.slots,
     style: style.value,
     thClasses: thClasses.value,
@@ -60,9 +62,9 @@ const providedData = computed<TableColumnComponent<T>>(() => ({
 const { parent, item } = useProviderChild<
     TableComponent,
     TableColumnComponent<T>
->({ data: providedData });
+>(rootRef, { data: providedData });
 
-// --- Computed Component Classes ---
+// #region --- Computed Component Classes ---
 
 const thClasses = defineClasses(
     [
@@ -112,6 +114,8 @@ const tdClasses = defineClasses(
     ],
 );
 
+// #endregion --- Computed Component Classes ---
+
 // --- SLOTS TYPED OBJECTS ---
 
 // these properties are just for type addings
@@ -124,7 +128,10 @@ const filters = {} as Record<string, string>;
 </script>
 
 <template>
-    <span data-oruga="table-column" :data-id="`table-${item.identifier}`">
+    <span
+        ref="rootElement"
+        data-oruga="table-column"
+        :data-id="`table-${item.identifier}`">
         {{ label }}
 
         <!--

--- a/packages/oruga/src/components/table/types.ts
+++ b/packages/oruga/src/components/table/types.ts
@@ -12,7 +12,7 @@ export type TableRow<V = unknown> = OptionsItem<V> & {
 export type TableColumn<T = unknown> = TableColumnProps<T>;
 
 export type TableColumnComponent<T = unknown> = TableColumn<T> & {
-    $el: ComponentPublicInstance;
+    $instance: ComponentPublicInstance;
     $slots: Slots;
     style: StyleValue;
     thClasses: ClassBind[];

--- a/packages/oruga/src/components/tabs/TabItem.vue
+++ b/packages/oruga/src/components/tabs/TabItem.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts" generic="T, C extends Component">
-import { computed, ref, useSlots, useId, type Component } from "vue";
+import {
+    computed,
+    ref,
+    useSlots,
+    useId,
+    useTemplateRef,
+    type Component,
+} from "vue";
 
 import PlainButton from "../utils/PlainButton";
 
@@ -44,6 +51,8 @@ const emits = defineEmits<{
 
 const itemValue = props.value ?? useId();
 
+const rootRef = useTemplateRef("rootElement");
+
 const slots = useSlots();
 
 // provided data is a computed ref to ensure reactivity
@@ -60,9 +69,10 @@ const providedData = computed<TabItemComponent<T>>(() => ({
 }));
 
 /** inject functionalities and data from the parent component */
-const { parent, item } = useProviderChild<TabsComponent, TabItemComponent<T>>({
-    data: providedData,
-});
+const { parent, item } = useProviderChild<TabsComponent, TabItemComponent<T>>(
+    rootRef,
+    { data: providedData },
+);
 
 const transitionName = ref();
 
@@ -110,7 +120,7 @@ function beforeLeave(): void {
     isTransitioning.value = true;
 }
 
-// --- Computed Component Classes ---
+// #region --- Computed Component Classes ---
 
 const tabClasses = defineClasses(
     ["tabClass", "o-tabs__tab"],
@@ -140,6 +150,8 @@ const tabIconClasses = defineClasses(["tabIconClass", "o-tabs__tab-icon"]);
 const tabLabelClasses = defineClasses(["tabLabelClass", "o-tabs__tab-label"]);
 
 const panelClasses = defineClasses(["tabPanelClass", "o-tabs__panel"]);
+
+// #endregion --- Computed Component Classes ---
 </script>
 
 <template>
@@ -154,6 +166,7 @@ const panelClasses = defineClasses(["tabPanelClass", "o-tabs__panel"]);
             v-show="isActive && visible"
             v-bind="$attrs"
             :id="`tabpanel-${item.identifier}`"
+            ref="rootElement"
             data-oruga="tabs-item"
             :data-id="`tabs-${item.identifier}`"
             :class="panelClasses"

--- a/packages/oruga/src/components/tabs/Tabs.vue
+++ b/packages/oruga/src/components/tabs/Tabs.vue
@@ -100,6 +100,7 @@ const { childItems } = useProviderParent<TabItemComponent<T>>({
 const items = computed<TabItem<T>[]>(() => {
     if (!childItems.value) return [];
     return childItems.value.map((column) => ({
+        el: column.el,
         index: column.index,
         identifier: column.identifier,
         ...toValue(column.data!),

--- a/packages/oruga/src/composables/useParentProvider.ts
+++ b/packages/oruga/src/composables/useParentProvider.ts
@@ -15,13 +15,21 @@ import { useDebounce } from "./useDebounce";
 import { useSequentialId } from "./useSequentialId";
 
 export type ProviderItem<T = unknown> = {
+    /** The root element of the item component */
+    el: MaybeRefOrGetter<HTMLElement | null>;
+    /** The index of the item component in the parent */
     index: number;
-    data?: T;
+    /** A unique identifier for the item component */
     identifier: string;
+    /** Item component data */
+    data?: T;
 };
 
 type PovidedData<P, I = unknown> = {
-    registerItem: (data?: I) => ProviderItem<I>;
+    registerItem: (
+        el: MaybeRefOrGetter<HTMLElement | null>,
+        data?: I,
+    ) => ProviderItem<I>;
     unregisterItem: (item: ProviderItem) => void;
     data?: ComputedRef<P>;
 };
@@ -101,10 +109,13 @@ export function useProviderParent<ItemData = unknown, ParentData = unknown>(
 
     const { nextSequence } = useSequentialId(1);
 
-    function registerItem(data?: ItemData): ProviderItem<ItemData> {
+    function registerItem(
+        el: MaybeRefOrGetter<HTMLElement | null>,
+        data?: ItemData,
+    ): ProviderItem<ItemData> {
         const index = childItems.value.length;
         const identifier = nextSequence();
-        const item = { index, data, identifier };
+        const item: ProviderItem<ItemData> = { el, index, identifier, data };
         // add new item to the child list
         childItems.value = [
             ...childItems.value,
@@ -152,6 +163,7 @@ type ProviderChildOptions<T = unknown> = {
 };
 
 export function useProviderChild<ParentData, ItemData = unknown>(
+    el: MaybeRefOrGetter<HTMLElement | null>,
     options: Omit<ProviderChildOptions<ItemData>, "needParent"> & {
         needParent: true;
     },
@@ -161,6 +173,7 @@ export function useProviderChild<ParentData, ItemData = unknown>(
 };
 
 export function useProviderChild<ParentData, ItemData = unknown>(
+    el: MaybeRefOrGetter<HTMLElement | null>,
     options: Omit<ProviderChildOptions<ItemData>, "needParent"> & {
         needParent: false;
     },
@@ -170,6 +183,7 @@ export function useProviderChild<ParentData, ItemData = unknown>(
 };
 
 export function useProviderChild<ParentData, ItemData = unknown>(
+    el: MaybeRefOrGetter<HTMLElement | null>,
     options: Omit<ProviderChildOptions<ItemData>, "needParent"> & {
         register: false;
     },
@@ -179,6 +193,7 @@ export function useProviderChild<ParentData, ItemData = unknown>(
 };
 
 export function useProviderChild<ParentData, ItemData = unknown>(
+    el: MaybeRefOrGetter<HTMLElement | null>,
     options: Omit<ProviderChildOptions<ItemData>, "needParent" | "register"> & {
         needParent: true;
         register: true;
@@ -189,6 +204,7 @@ export function useProviderChild<ParentData, ItemData = unknown>(
 };
 
 export function useProviderChild<ParentData, ItemData = unknown>(
+    el: MaybeRefOrGetter<HTMLElement | null>,
     options?: Omit<ProviderChildOptions<ItemData>, "needParent" | "register">,
 ): {
     parent: Readonly<Ref<ParentData>>;
@@ -200,6 +216,7 @@ export function useProviderChild<ParentData, ItemData = unknown>(
  * @param options additional options
  */
 export function useProviderChild<ParentData, ItemData = unknown>(
+    el: MaybeRefOrGetter<HTMLElement | null>,
     options?: ProviderChildOptions<ItemData>,
 ): {
     parent: Readonly<Ref<ParentData | undefined>>;
@@ -231,6 +248,7 @@ export function useProviderChild<ParentData, ItemData = unknown>(
 
     if (parent && options.register)
         item.value = parent.registerItem(
+            el,
             options?.data,
         ) as ProviderItem<ItemData>;
 

--- a/packages/oruga/src/composables/useScrollHelper.ts
+++ b/packages/oruga/src/composables/useScrollHelper.ts
@@ -1,4 +1,4 @@
-import { getCurrentScope, type MaybeRefOrGetter } from "vue";
+import { getCurrentScope, type Component, type MaybeRefOrGetter } from "vue";
 import { isDefined } from "@/utils/helpers";
 import { isClient } from "@/utils/ssr";
 import { unrefElement } from "./unrefElement";
@@ -126,11 +126,13 @@ export function isScrollable(
  * If the child is not visible, scroll the parent to the child's position.
  */
 export function scrollElementInView(
-    scrollableParent: MaybeRefOrGetter<HTMLElement>,
-    childElement: MaybeRefOrGetter<HTMLElement>,
+    scrollableParent: MaybeRefOrGetter<HTMLElement | Component | null>,
+    childElement: MaybeRefOrGetter<HTMLElement | Component | null>,
 ): void {
     const parent = unrefElement(scrollableParent);
     const element = unrefElement(childElement);
+
+    if (!parent || !element) return;
 
     const { offsetHeight, offsetTop } = element;
     const { offsetHeight: parentOffsetHeight, scrollTop } = parent;

--- a/packages/oruga/src/index.ts
+++ b/packages/oruga/src/index.ts
@@ -15,6 +15,7 @@ export * from "./utils/helpers";
 
 // export some useful composables
 export {
+    findFocusable,
     useTrapFocus,
     useEventListener,
     useClickOutside,


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Always make the root element of an provider child item available to the provider parent
