### PR TITLE
feat(table): deprecate `seachable` | add `filterable`

### DIFF
--- a/packages/docs/components/Table.md
+++ b/packages/docs/components/Table.md
@@ -111,6 +111,7 @@ It allows tabular data to be displayed in a responsive way with special case cel
 | Event name          | Properties                                                                                                                                                                               | Description                                        |
 | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
 | page-change         | **page** `number` - updated page                                                                                                                                                         | on pagination page change event                    |
+| filter              | **column** `TableColumn` - column data<br/>**value** `string` - filter input value<br/>**event** `Event` - native event                                                                  | on native filter event                             |
 | dblclick            | **row** `T` - row data<br/>**index** `number` - index of clicked row<br/>**event** `Event` - native click event                                                                          | on row double click event                          |
 | mouseenter          | **row** `T` - row data<br/>**index** `number` - index of clicked row<br/>**event** `Event` - native mouseenter event                                                                     | on row mouseenter event                            |
 | mouseleave          | **row** `T` - row data<br/>**index** `number` - index of clicked row<br/>**event** `Event` - native mouseleave event                                                                     | on row mouseleave event                            |
@@ -175,9 +176,11 @@ It allows tabular data to be displayed in a responsive way with special case cel
 
 | Prop name        | Description                                            | Type                                                    | Values                      | Default                                                     |
 | ---------------- | ------------------------------------------------------ | ------------------------------------------------------- | --------------------------- | ----------------------------------------------------------- |
+| customFilter     | Define a custom filter funtion when filterable         | ((row: unknown, filter: string) =&gt; boolean)          | -                           |                                                             |
 | customSearch     | Define a custom filter funtion for the search          | ((row: unknown, filter: string) =&gt; boolean)          | -                           |                                                             |
 | customSort       | Define a custom sort function                          | ((a: unknown, b: unknown, isAsc: boolean) =&gt; number) | -                           |                                                             |
 | field            | Define an object property key if data is an object     | string                                                  | -                           |                                                             |
+| filterable       | Enable an additional filterbar below the column header | boolean                                                 | -                           | <code style='white-space: nowrap; padding: 0;'>false</code> |
 | formatter        | Provide a formatter function to edit the output        | ((value: unknown, row: unknown) =&gt; string)           | -                           |                                                             |
 | headerSelectable | Make header selectable                                 | boolean                                                 | -                           | <code style='white-space: nowrap; padding: 0;'>false</code> |
 | hidden           | Define whether the column is visible or not            | boolean                                                 | -                           | <code style='white-space: nowrap; padding: 0;'>false</code> |
@@ -200,6 +203,7 @@ It allows tabular data to be displayed in a responsive way with special case cel
 | header     | Override header label     | **column** `TableColumn` - column definition<br/>**index** `number` - column index                                                                                                                              |
 | subheading | Override subheading label | **column** `TableColumn` - column definition<br/>**index** `number` - column index                                                                                                                              |
 | searchable | Override searchable input | **column** `TableColumn` - column definition<br/>**index** `number` - column index<br/>**filters** `object` - active filters object                                                                             |
+| filter     | Override searchable input | **column** `TableColumn` - column definition<br/>**index** `number` - column index<br/>**filters** `object` - active filters object                                                                             |
 
 </section>
 

--- a/packages/oruga/src/components/table/TableColumn.vue
+++ b/packages/oruga/src/components/table/TableColumn.vue
@@ -26,12 +26,14 @@ const props = withDefaults(defineProps<TableColumnProps<T, K>>(), {
     numeric: false,
     position: undefined,
     searchable: false,
+    filterable: false,
     sortable: false,
     hidden: false,
     sticky: false,
     headerSelectable: false,
     customSort: undefined,
     customSearch: undefined,
+    customFilter: undefined,
     thAttrs: undefined,
     tdAttrs: undefined,
 });
@@ -169,12 +171,25 @@ const filters = {} as Record<string, string>;
 
             <!--
                 @slot Override searchable input
+                @deprecated use `filter` instead
                 @binding {TableColumn} column - column definition
                 @binding {number} index - column index
                 @binding {object} filters - active filters object
             -->
             <slot
                 name="searchable"
+                :column="column"
+                :index="index"
+                :filters="filters" />
+
+            <!--
+                @slot Override searchable input
+                @binding {TableColumn} column - column definition
+                @binding {number} index - column index
+                @binding {object} filters - active filters object
+            -->
+            <slot
+                name="filter"
                 :column="column"
                 :index="index"
                 :filters="filters" />

--- a/packages/oruga/src/components/table/props.ts
+++ b/packages/oruga/src/components/table/props.ts
@@ -153,7 +153,10 @@ export type TableProps<T> = {
     filtersIcon?: string;
     /** Placeholder of the column search input */
     filtersPlaceholder?: string;
-    /** Add a native event to filter */
+    /**
+     * Add a native event to filter
+     * @deprecated use `filter` event instead
+     */
     filtersEvent?: string;
     /** Filtering debounce time (in milliseconds) */
     filterDebounce?: number;
@@ -286,8 +289,13 @@ export type TableColumnProps<
      * @values left, centered, right
      */
     position?: "left" | "centered" | "right";
-    /** Enable an additional searchbar below the column header */
+    /**
+     * Enable an additional searchbar below the column header
+     * @deprecated use `filterable` instead
+     */
     searchable?: boolean;
+    /** Enable an additional filterbar below the column header */
+    filterable?: boolean;
     /** Enable column sortability */
     sortable?: boolean;
     /** Define whether the column is visible or not */
@@ -298,8 +306,13 @@ export type TableColumnProps<
     headerSelectable?: boolean;
     /** Define a custom sort function */
     customSort?: (a: T, b: T, isAsc: boolean) => number;
-    /** Define a custom filter funtion for the search */
+    /**
+     * Define a custom filter funtion for the search
+     * @deprecated use `customFilter` instead
+     */
     customSearch?: (row: T, filter: string) => boolean;
+    /** Define a custom filter funtion when filterable */
+    customFilter?: (row: T, filter: string) => boolean;
     /** Adds native attributes to th */
     thAttrs?: object;
     /** Adds native attributes to td */


### PR DESCRIPTION
## Proposed Changes

- deprecate TableColumn `seachable` prop - use new `filterable` prop instead
- deprecate TableColumn `seachable` slot - use new `filter` slot instead
- deprecate Table `filtersEvent` prop - use `@filter` event instead
