### PR TITLE
fix(icon): transform internal icons based on the icon pack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2709,42 +2709,42 @@
       }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.0.0.tgz",
-      "integrity": "sha512-PGMrIYXLGA5K8RWy8zwBkd4vFi4z7ubxtet6Yn13Plf6krRTwPbdlCwlcfmoX0R7B4Z643QvrtHmdQ5fNtfFCg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.0.1.tgz",
+      "integrity": "sha512-0VpNtO5cNe1/HQWMkl4OdncYK/mv9hnBte0Ew0n6DMzmo3Q3WzDFABHm6LeNTipt5zAyhQ6Ugjiu8aLaEjh1gg==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.0.0.tgz",
-      "integrity": "sha512-X48nISrSOa89zu2VMljC4XaRf8NmgTwQBVHfS2Nu5G00ZwM31oOVrAtGxZF3b6wDYf9lJsf/Eq4cCSFKIkOWPQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.0.1.tgz",
+      "integrity": "sha512-RLmb9U6H2rJDnGxEqXxzy7ANPrQz7WK2/eTjdZqyU9uRU5W+FkAec9uU5gTYzFBH7aoXIw2WTJSCJR4KPlReQw==",
       "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.0.0.tgz",
-      "integrity": "sha512-obBEF+zd98r/KtKVW6A+8UGWeaOoyMpl6Q9P3FzHsOnsg742aXsl8v+H/zp09qSSu/a/Hxe9LNKzbBaQq1CEbA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.0.1.tgz",
+      "integrity": "sha512-x0cR55ILVqFpUioSMf6ebpRCMXMcheGN743P05W2RB5uCNpJUqWIqW66Lap8PfL/lngvjTbZj0BNSUweIr/fHQ==",
       "license": "MIT",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.0.0"
+        "@fortawesome/fontawesome-common-types": "7.0.1"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.0.0.tgz",
-      "integrity": "sha512-njSLAllkOddYDCXgTFboXn54Oe5FcvpkWq+FoetOHR64PbN0608kM02Lze0xtISGpXgP+i26VyXRQA0Irh3Obw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.0.1.tgz",
+      "integrity": "sha512-esKuSrl1WMOTMDLNt38i16VfLe/gRZt2ZAJ3Yw7slfs7sj583MKqNFqO57zmhknk1Sya6f9Wys89aCzIJkcqlg==",
       "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.0.0"
+        "@fortawesome/fontawesome-common-types": "7.0.1"
       },
       "engines": {
         "node": ">=6"
@@ -13406,8 +13406,8 @@
       "version": "0.11.5",
       "license": "MIT",
       "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^7.0.0",
-        "@fortawesome/free-solid-svg-icons": "^7.0.0",
+        "@fortawesome/fontawesome-svg-core": "^7.0.1",
+        "@fortawesome/free-solid-svg-icons": "^7.0.1",
         "@fortawesome/vue-fontawesome": "^3.1.1",
         "@highlightjs/vue-plugin": "2.1.2",
         "@oruga-ui/theme-bootstrap": "0.9.4",
@@ -13466,9 +13466,9 @@
       "version": "0.11.5",
       "license": "MIT",
       "dependencies": {
-        "@fortawesome/fontawesome-free": "7.0.0",
-        "@fortawesome/fontawesome-svg-core": "^7.0.0",
-        "@fortawesome/free-solid-svg-icons": "^7.0.0",
+        "@fortawesome/fontawesome-free": "7.0.1",
+        "@fortawesome/fontawesome-svg-core": "^7.0.1",
+        "@fortawesome/free-solid-svg-icons": "^7.0.1",
         "@fortawesome/vue-fontawesome": "^3.1.1",
         "@highlightjs/vue-plugin": "2.1.2",
         "highlight.js": "11.11.1",

--- a/packages/docs/.vitepress/theme/index.ts
+++ b/packages/docs/.vitepress/theme/index.ts
@@ -113,7 +113,6 @@ export default {
 
         // basic docs config
         let orugaConfig: OrugaOptions = {
-            environment: "docs",
             iconPack: "fas",
             iconComponent: "vue-fontawesome",
         };

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -16,8 +16,8 @@
     "docs:gen:watch": "tsx src/docgen.ts --watch"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^7.0.0",
-    "@fortawesome/free-solid-svg-icons": "^7.0.0",
+    "@fortawesome/fontawesome-svg-core": "^7.0.1",
+    "@fortawesome/free-solid-svg-icons": "^7.0.1",
     "@fortawesome/vue-fontawesome": "^3.1.1",
     "@highlightjs/vue-plugin": "2.1.2",
     "@oruga-ui/theme-bootstrap": "0.9.4",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -53,9 +53,9 @@
     "vue": "^3.0.0"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "7.0.0",
-    "@fortawesome/fontawesome-svg-core": "^7.0.0",
-    "@fortawesome/free-solid-svg-icons": "^7.0.0",
+    "@fortawesome/fontawesome-free": "7.0.1",
+    "@fortawesome/fontawesome-svg-core": "^7.0.1",
+    "@fortawesome/free-solid-svg-icons": "^7.0.1",
     "@fortawesome/vue-fontawesome": "^3.1.1",
     "@highlightjs/vue-plugin": "2.1.2",
     "highlight.js": "11.11.1",

--- a/packages/oruga/src/components/icon/Icon.vue
+++ b/packages/oruga/src/components/icon/Icon.vue
@@ -40,21 +40,25 @@ const emits = defineEmits<{
     click: [event: Event];
 }>();
 
-const environment = getOption("environment");
-
 const rootStyle = computed(() => {
     const style = {};
     if (props.rotation) style["transform"] = `rotate(${props.rotation}deg)`;
     return style;
 });
 
+/** get the compiled icon packs */
 const icons = getIcons();
 
+/** icon configuration defined by the corresponding icon pack */
 const iconConfig = computed(() => icons[props.pack]);
 
+/** icon prefix defined by the icon configuration */
 const iconPrefix = computed(() => iconConfig.value?.iconPrefix ?? "");
 
-const customSizeByPack = computed(() => {
+/** icon size defined by the icon configuration or custom */
+const iconSize = computed(() => {
+    if(props.customSize) return props.customSize;
+
     if (iconConfig.value?.sizes) {
         if (props.size && iconConfig.value.sizes[props.size] !== undefined)
             return iconConfig.value.sizes[props.size];
@@ -63,8 +67,6 @@ const customSizeByPack = computed(() => {
     }
     return null;
 });
-
-const computedSize = computed(() => props.customSize || customSizeByPack.value);
 
 /**
  * Internal icon name based on the pack.
@@ -77,9 +79,11 @@ const computedIcon = computed(
 
 /** Equivalent icon name of the MDI. */
 function getEquivalentIconOf(value: string): string {
-    // Only transform the class if the env is docs prop is set to true
-    if (environment != "docs") return value;
+    // only transform the class if 
     if (
+        // the pack is part of fontawesome icons
+        props.pack.toLocaleLowerCase().startsWith("fa") &&
+        // and an internal icon quivalent is available
         iconConfig.value?.internalIcons &&
         iconConfig.value?.internalIcons[value]
     )
@@ -134,10 +138,10 @@ const rootClasses = defineClasses(
             :is="component"
             v-if="component"
             :icon="[pack, computedIcon]"
-            :size="computedSize"
-            :class="[customClass]" />
+            :size="iconSize"
+            :class="customClass"/>
 
         <!-- native css icon -->
-        <i v-else :class="[pack, computedIcon, computedSize, customClass]" />
+        <i v-else :class="[pack, computedIcon, iconSize, customClass]" />
     </span>
 </template>

--- a/packages/oruga/src/components/icon/Icon.vue
+++ b/packages/oruga/src/components/icon/Icon.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
-import { getDefault, getOption } from "@/utils/config";
+import { getDefault } from "@/utils/config";
 import getIcons from "@/utils/icons";
 import { defineClasses } from "@/composables";
 
@@ -57,7 +57,7 @@ const iconPrefix = computed(() => iconConfig.value?.iconPrefix ?? "");
 
 /** icon size defined by the icon configuration or custom */
 const iconSize = computed(() => {
-    if(props.customSize) return props.customSize;
+    if (props.customSize) return props.customSize;
 
     if (iconConfig.value?.sizes) {
         if (props.size && iconConfig.value.sizes[props.size] !== undefined)
@@ -79,7 +79,7 @@ const computedIcon = computed(
 
 /** Equivalent icon name of the MDI. */
 function getEquivalentIconOf(value: string): string {
-    // only transform the class if 
+    // only transform the class if
     if (
         // the pack is part of fontawesome icons
         props.pack.toLocaleLowerCase().startsWith("fa") &&
@@ -139,7 +139,7 @@ const rootClasses = defineClasses(
             v-if="component"
             :icon="[pack, computedIcon]"
             :size="iconSize"
-            :class="customClass"/>
+            :class="customClass" />
 
         <!-- native css icon -->
         <i v-else :class="[pack, computedIcon, iconSize, customClass]" />

--- a/packages/oruga/src/types/config.ts
+++ b/packages/oruga/src/types/config.ts
@@ -94,11 +94,6 @@ export type GlobalConfig = Partial<{
      * you can specify the override behaviour here globaly.
      */
     override: boolean;
-    /**
-     * @private
-     * @ignore
-     */
-    environment: "docs" | "examples";
 }>;
 
 export interface OrugaOptions extends GlobalConfig {}

--- a/packages/oruga/src/utils/icons.ts
+++ b/packages/oruga/src/utils/icons.ts
@@ -48,9 +48,9 @@ function getFaIcons(): IconConfig {
             "emoticon-sad": "frown",
         },
     } as const;
-};
+}
 
-function getIcons (): Record<string, IconConfig> {
+function getIcons(): Record<string, IconConfig> {
     const faIcons = getFaIcons();
     let icons: Record<string, IconConfig> = {
         mdi: mdiIcons,
@@ -66,6 +66,6 @@ function getIcons (): Record<string, IconConfig> {
     if (customIconPacks) icons = merge(icons, customIconPacks, true);
 
     return icons;
-};
+}
 
 export default getIcons;

--- a/packages/oruga/src/utils/icons.ts
+++ b/packages/oruga/src/utils/icons.ts
@@ -8,26 +8,26 @@ export type IconConfig = {
 };
 
 const mdiIcons = {
+    iconPrefix: "mdi-",
     sizes: {
         default: "mdi-24px",
         small: "",
         medium: "mdi-36px",
         large: "mdi-48px",
     },
-    iconPrefix: "mdi-",
-};
+} as const;
 
-const faIcons = (): IconConfig => {
+function getFaIcons(): IconConfig {
     const iconComponent = getOption("iconComponent");
     const faIconPrefix = iconComponent ? "" : "fa-";
     return {
+        iconPrefix: faIconPrefix,
         sizes: {
             default: "",
             small: "sm",
             medium: "lg",
             large: "xl",
         },
-        iconPrefix: faIconPrefix,
         internalIcons: {
             check: "check",
             information: "info-circle",
@@ -47,18 +47,19 @@ const faIcons = (): IconConfig => {
             loading: "circle-notch",
             "emoticon-sad": "frown",
         },
-    };
+    } as const;
 };
 
-const getIcons = (): Record<string, IconConfig> => {
+function getIcons (): Record<string, IconConfig> {
+    const faIcons = getFaIcons();
     let icons: Record<string, IconConfig> = {
         mdi: mdiIcons,
-        fa: faIcons(),
-        fas: faIcons(),
-        far: faIcons(),
-        fad: faIcons(),
-        fab: faIcons(),
-        fal: faIcons(),
+        fa: faIcons,
+        fas: faIcons,
+        far: faIcons,
+        fad: faIcons,
+        fab: faIcons,
+        fal: faIcons,
     };
 
     const customIconPacks = getOption("customIconPacks");


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #1388 

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- remove internal `environment` config
- define internal icons based on the icon pack
- update fontawesome dependency
