### PR TITLE
refactor(table): prevent circular type dependency

### DIFF
--- a/packages/oruga/src/components/table/Table.vue
+++ b/packages/oruga/src/components/table/Table.vue
@@ -1366,7 +1366,7 @@ defineExpose({ rows: tableRows, sort: sortByField });
                                 ">
                                 <o-slot-component
                                     v-if="column.$slots?.header"
-                                    :component="column.$instance"
+                                    :component="column"
                                     name="header"
                                     tag="span"
                                     :class="thLabelClasses"
@@ -1452,7 +1452,7 @@ defineExpose({ rows: tableRows, sort: sortByField });
                                     ">
                                     <o-slot-component
                                         v-if="column.$slots?.searchable"
-                                        :component="column.$instance"
+                                        :component="column"
                                         name="searchable"
                                         tag="span"
                                         :props="{
@@ -1462,7 +1462,7 @@ defineExpose({ rows: tableRows, sort: sortByField });
                                         }" />
                                     <o-slot-component
                                         v-else-if="column.$slots?.filter"
-                                        :component="column.$instance"
+                                        :component="column"
                                         name="filter"
                                         tag="span"
                                         :props="{
@@ -1520,7 +1520,7 @@ defineExpose({ rows: tableRows, sort: sortByField });
                                 ]">
                                 <o-slot-component
                                     v-if="column.$slots?.subheading"
-                                    :component="column.$instance"
+                                    :component="column"
                                     name="subheading"
                                     tag="span"
                                     :props="{
@@ -1624,7 +1624,7 @@ defineExpose({ rows: tableRows, sort: sortByField });
                                 <o-slot-component
                                     v-if="!column.hidden"
                                     v-bind="column.tdAttrsData[row.index]"
-                                    :component="column.$instance"
+                                    :component="column"
                                     name="default"
                                     tag="td"
                                     :class="[

--- a/packages/oruga/src/components/table/props.ts
+++ b/packages/oruga/src/components/table/props.ts
@@ -268,10 +268,9 @@ export type TableClasses = Partial<{
     loadingClasses: object;
 }>;
 
-export type TableColumnProps<
-    T,
-    K extends string = T extends never | unknown ? string : DeepKeys<T>,
-> = {
+export type FieldKey<T> = T extends never | unknown ? string : DeepKeys<T>;
+
+export type TableColumnProps<T, K extends string = FieldKey<T>> = {
     /** Define the column label */
     label?: string;
     /** Define an object property key if data is an object */

--- a/packages/oruga/src/components/table/types.ts
+++ b/packages/oruga/src/components/table/types.ts
@@ -1,8 +1,8 @@
-import type { ComponentPublicInstance, Slots, StyleValue } from "vue";
+import type { Slots, StyleValue } from "vue";
 import type { OptionsItem, ProviderItem } from "@/composables";
 import type { ClassBinding } from "@/types";
 
-import type { TableColumnProps } from "./props";
+import type { FieldKey, TableColumnProps } from "./props";
 
 export type TableRow<V = unknown> = OptionsItem<V> & {
     /** table index position of the current row */
@@ -11,8 +11,10 @@ export type TableRow<V = unknown> = OptionsItem<V> & {
 
 export type TableColumn<T = unknown> = TableColumnProps<T>;
 
-export type TableColumnComponent<T = unknown> = TableColumn<T> & {
-    $instance: ComponentPublicInstance;
+export type TableColumnComponent<
+    T,
+    K extends string = FieldKey<T>,
+> = TableColumnProps<T, K> & {
     $slots: Slots;
     style: StyleValue;
     thClasses: ClassBinding[];
@@ -23,8 +25,11 @@ export type TableComponent = {
     isColumnSorted(column: ProviderItem): boolean;
 };
 
-export type TableColumnItem<T = unknown> = Omit<ProviderItem, "data"> &
-    TableColumnComponent<T> & {
+export type TableColumnItem<T, K extends string = FieldKey<T>> = Omit<
+    ProviderItem,
+    "data"
+> &
+    TableColumnComponent<T, K> & {
         value: TableColumn<T>;
         thAttrsData: object;
         tdAttrsData: Array<object>;

--- a/packages/oruga/src/components/utils/SlotComponent.ts
+++ b/packages/oruga/src/components/utils/SlotComponent.ts
@@ -1,7 +1,7 @@
 import {
     createVNode,
     defineComponent,
-    type DefineComponent,
+    type Slots,
     type VNode,
     type VNodeChild,
     type VNodeTypes,
@@ -28,16 +28,18 @@ type SlotComponentProps<C extends VNodeTypes> = {
     class?: ClassBinding | ClassBinding[];
 };
 
-/** This components renders a specific slot and only the slot of another component */
-export default defineComponent<SlotComponentProps<any>>(
-    <C extends DefineComponent>(props: SlotComponentProps<C>, { slots }) => {
+/** This components renders only a specific slot of another component */
+export default defineComponent<SlotComponentProps<{ $slots: Slots }>>(
+    <C extends { $slots: Slots }>(props: SlotComponentProps<C>, { slots }) => {
         const _props = { tag: "div", name: "default", ...props };
 
         return (): VNode => {
             let slot: VNodeChild | (() => VNodeChild) = (): VNodeChild =>
-                props.component.$slots[_props.name]
-                    ? props.component.$slots[_props.name](props.props)
-                    : slots.default
+                // render the component slot if available
+                typeof props.component.$slots[_props.name] === "function"
+                    ? props.component.$slots[_props.name]!(props.props)
+                    : // render the default if no component slot override is available
+                      typeof slots.default === "function"
                       ? slots.default()
                       : undefined;
             if (typeof _props.tag === "string") {


### PR DESCRIPTION
## Proposed Changes

- update SlotComnponent typing
- remove unsessary `$instance` from TableColumn provided data
- strongly type the `thClasses` variable to prevent circular type dependency because `parent` is used in the definition of any class and the variable is used by the parent
