### PR TITLE
feat(autocomplete): rename class `itemGroupTitleClass` to `itemGroupClass`

### DIFF
--- a/packages/oruga/src/components/autocomplete/Autocomplete.vue
+++ b/packages/oruga/src/components/autocomplete/Autocomplete.vue
@@ -393,8 +393,8 @@ const itemEmptyClasses = defineClasses([
 ]);
 
 const itemGroupClasses = defineClasses([
-    "itemGroupTitleClass",
-    "o-autocomplete__item-group-title",
+    "itemGroupClass",
+    "o-autocomplete__item-group",
 ]);
 
 const itemHeaderClasses = defineClasses([

--- a/packages/oruga/src/components/autocomplete/examples/inspector.vue
+++ b/packages/oruga/src/components/autocomplete/examples/inspector.vue
@@ -26,9 +26,9 @@ const inspectData: InspectData<
             data.active = true;
         },
     },
-    itemGroupTitleClass: {
-        class: "itemGroupTitleClass",
-        description: "Class of the menu items group title.",
+    itemGroupClass: {
+        class: "itemGroupClass",
+        description: "Class of the menu group item.",
         action: (data): void => {
             data.input = "Q";
             data.active = true;

--- a/packages/oruga/src/components/autocomplete/props.ts
+++ b/packages/oruga/src/components/autocomplete/props.ts
@@ -118,8 +118,8 @@ export type AutocompleteClasses = Partial<{
     rootClass: ComponentClass;
     /** Class of the menu items */
     itemClass: ComponentClass;
-    /** Class of the menu items group title */
-    itemGroupTitleClass: ComponentClass;
+    /** Class of the menu group item */
+    itemGroupClass: ComponentClass;
     /** Class of the empty menu placeholder item */
     itemEmptyClass: ComponentClass;
     /** Class of the menu header item */

--- a/packages/oruga/src/components/types.ts
+++ b/packages/oruga/src/components/types.ts
@@ -62,8 +62,8 @@ In addition, any CSS selector string or an actual DOM node can be used. */
                 rootClass: ClassDefinition;
                 /** Class of the menu items */
                 itemClass: ClassDefinition;
-                /** Class of the menu items group title */
-                itemGroupTitleClass: ClassDefinition;
+                /** Class of the menu group item */
+                itemGroupClass: ClassDefinition;
                 /** Class of the empty menu placeholder item */
                 itemEmptyClass: ClassDefinition;
                 /** Class of the menu header item */


### PR DESCRIPTION

## Proposed Changes

- rename class `itemGroupTitleClass` to `itemGroupClass` to unify class namings

BREAKING CHANGE: rename class `itemGroupTitleClass` to `itemGroupClass`
