### PR TITLE
refactor(ParentProvider): increase parent provider performance and type strictness 

### DIFF
--- a/packages/oruga/src/components/carousel/CarouselItem.vue
+++ b/packages/oruga/src/components/carousel/CarouselItem.vue
@@ -30,13 +30,13 @@ const rootRef = useTemplateRef("rootElement");
 /** inject functionalities and data from the parent component */
 const { parent, item } = useProviderChild<CarouselComponent>(rootRef);
 
-const isActive = computed(() => parent.value.activeIndex === item.value.index);
+const isActive = computed(() => parent.value.activeIndex === item.index);
 
 const itemStyle = computed(() => ({ width: `${parent.value.itemWidth}px` }));
 
 function onClick(event: Event): void {
     if (isActive.value) parent.value.onClick(event);
-    if (props.clickable) parent.value.setActive(item.value.index);
+    if (props.clickable) parent.value.setActive(item.index);
 }
 
 // #region --- Computed Component Classes ---

--- a/packages/oruga/src/components/dropdown/DropdownItem.vue
+++ b/packages/oruga/src/components/dropdown/DropdownItem.vue
@@ -43,8 +43,10 @@ const rootRef = useTemplateRef("rootElement");
 
 // provided data is a computed ref to ensure reactivity
 const providedData = computed<DropdownItemComponent<T>>(() => ({
-    ...props,
-    value: itemValue,
+    value: itemValue as T,
+    disabled: props.disabled,
+    hidden: props.hidden,
+    clickable: props.clickable,
     selectItem,
 }));
 
@@ -54,6 +56,7 @@ const { parent, item } = useProviderChild<
     DropdownItemComponent<T>
 >(rootRef, { data: providedData });
 
+/** Shows if the item is clickable or not. */
 const isClickable = computed(
     () => !parent.value.disabled && !props.disabled && props.clickable,
 );
@@ -68,19 +71,19 @@ const isSelected = computed(() => {
 });
 
 const isFocused = computed(
-    () => item.value.identifier === parent.value.focsuedIdentifier,
+    () => item.identifier === parent.value.focsuedIdentifier,
 );
 
 /** Click listener, select the item. */
 function selectItem(event: Event): void {
     if (!isClickable.value) return;
-    parent.value.selectItem(item.value, event);
+    parent.value.selectItem(item, event);
     emits("click", itemValue as T, event);
 }
 
 /** Hover listener, focus the item. */
 function focusItem(): void {
-    parent.value.focusItem(item.value);
+    parent.value.focusItem(item);
 }
 
 // #region --- Computed Component Classes ---

--- a/packages/oruga/src/components/dropdown/types.ts
+++ b/packages/oruga/src/components/dropdown/types.ts
@@ -12,7 +12,10 @@ export type DropdownComponent<T> = {
     focusItem: (value: DropdownChildItem<T>) => void;
 };
 
-export type DropdownItemComponent<T> = DropdownItemProps<T> & {
+export type DropdownItemComponent<T> = Pick<
+    DropdownItemProps<T>,
+    "value" | "disabled" | "hidden" | "clickable"
+> & {
     selectItem: (event: Event) => void;
 };
 

--- a/packages/oruga/src/components/listbox/ListItem.vue
+++ b/packages/oruga/src/components/listbox/ListItem.vue
@@ -47,9 +47,8 @@ const rootRef = useTemplateRef<HTMLElement>("rootElement");
 
 // provided data is a computed ref to ensure reactivity
 const providedData = computed<ListItemComponent<T>>(() => ({
-    ...props,
-    value: itemValue,
-    hidden: isHidden,
+    value: itemValue as T,
+    hidden: isHidden.value,
     clickItem,
     setHidden,
     isViable,
@@ -81,19 +80,19 @@ const isSelected = computed(() => {
 });
 
 const isFocused = computed(
-    () => item.value.identifier === parent.value.focsuedIdentifier,
+    () => item.identifier === parent.value.focsuedIdentifier,
 );
 
 /** Click listener, toggle the selection of the item. */
 function clickItem(event: Event): void {
     if (isDisabled.value) return;
-    parent.value.selectItem(item.value, !isSelected.value);
+    parent.value.selectItem(item, !isSelected.value);
     emits("click", itemValue as T, event);
 }
 
 /** Set the item as focused element. */
 function focusItem(): void {
-    parent.value.setFocus(item.value);
+    parent.value.setFocus(item);
 }
 
 /** Checks if the item is viable (not disabled or hidden). */

--- a/packages/oruga/src/components/listbox/Listbox.vue
+++ b/packages/oruga/src/components/listbox/Listbox.vue
@@ -155,10 +155,7 @@ const provideData = computed<ListboxComponent<T>>(() => ({
 const { childItems } = useProviderParent<
     ListItemComponent<T>,
     ListboxComponent<T>
->({
-    rootRef: containerRef,
-    data: provideData,
-});
+>({ rootRef: containerRef, data: provideData });
 
 const hasVisableItems = computed(
     () =>

--- a/packages/oruga/src/components/listbox/types.ts
+++ b/packages/oruga/src/components/listbox/types.ts
@@ -12,7 +12,10 @@ export type ListboxComponent<T> = {
     setFocus: (value: ListItem<T>) => void;
 };
 
-export type ListItemComponent<T> = ListItemProps<T> & {
+export type ListItemComponent<T> = Pick<
+    ListItemProps<T>,
+    "value" | "hidden"
+> & {
     clickItem: (event: Event) => void;
     setHidden: (hidden: boolean) => void;
     isViable: () => boolean;

--- a/packages/oruga/src/components/menu/MenuItem.vue
+++ b/packages/oruga/src/components/menu/MenuItem.vue
@@ -86,8 +86,9 @@ const menuItem = useProviderChild<MenuItemProvider<T>>(rootRef, {
 
 // provided data is a computed ref to ensure reactivity
 const providedData = computed<MenuItemComponent<T>>(() => ({
-    ...props,
-    value: itemValue,
+    value: itemValue as T,
+    disabled: props.disabled,
+    hidden: props.hidden,
     parent: menuItem.parent.value,
     hasChildren: hasChildren.value,
     expanded: isExpanded.value,
@@ -114,7 +115,7 @@ const isActive = defineModel<boolean>("active", { default: false });
 const hasChildren = computed(() => !!childItems.value.length);
 
 const isFocused = computed(
-    () => item.value.identifier === parent.value.focsuedIdentifier,
+    () => item.identifier === parent.value.focsuedIdentifier,
 );
 
 function selectItem(event: Event): void {
@@ -122,7 +123,7 @@ function selectItem(event: Event): void {
     triggerReset();
     isActive.value = !isActive.value;
     if (parent.value.accordion) isExpanded.value = isActive.value;
-    parent.value.selectItem(isActive.value ? item.value : undefined);
+    parent.value.selectItem(isActive.value ? item : undefined);
     emits("click", itemValue as T, event);
 }
 
@@ -130,13 +131,11 @@ function triggerReset(childs?: ProviderItem<MenuItemComponent<T>>[]): void {
     // The point of this method is to collect references to the clicked item and any parent,
     // this way we can skip resetting those elements.
     if (typeof menuItem.parent.value?.triggerReset === "function") {
-        menuItem.parent.value.triggerReset(
-            childs ? [item.value, ...childs] : [item.value],
-        );
+        menuItem.parent.value.triggerReset(childs ? [item, ...childs] : [item]);
     }
     // else if not a sub item reset parent menu
     else if (typeof parent.value.resetMenu === "function") {
-        parent.value.resetMenu(childs ? [item.value, ...childs] : [item.value]);
+        parent.value.resetMenu(childs ? [item, ...childs] : [item]);
     }
 }
 

--- a/packages/oruga/src/components/menu/types.ts
+++ b/packages/oruga/src/components/menu/types.ts
@@ -12,7 +12,10 @@ export type MenuComponent<T> = {
     resetMenu: (excludedItems?: ProviderItem<MenuItemComponent<T>>[]) => void;
 };
 
-export type MenuItemComponent<T> = MenuItemProps<T> & {
+export type MenuItemComponent<T> = Pick<
+    MenuItemProps<T>,
+    "value" | "disabled" | "hidden"
+> & {
     parent: MenuItemProvider<T> | undefined;
     hasChildren: boolean;
     expanded: boolean;

--- a/packages/oruga/src/components/steps/StepItem.vue
+++ b/packages/oruga/src/components/steps/StepItem.vue
@@ -7,6 +7,7 @@ import {
     useTemplateRef,
     type Component,
     type Ref,
+    type ComputedRef,
 } from "vue";
 
 import { getDefault } from "@/utils/config";
@@ -59,8 +60,13 @@ const slots = useSlots();
 
 // provided data is a computed ref to ensure reactivity
 const providedData = computed<StepItemComponent<T>>(() => ({
-    ...props,
-    value: itemValue,
+    value: itemValue as T,
+    label: props.label,
+    step: props.step,
+    disabled: props.disabled,
+    visible: props.visible,
+    icon: props.icon,
+    iconPack: props.iconPack,
     $slots: slots,
     stepClasses: stepClasses.value,
     iconClasses: stepIconClasses.value,
@@ -77,10 +83,9 @@ const { parent, item } = useProviderChild<StepsComponent, StepItemComponent<T>>(
     { data: providedData },
 );
 
-const transitionName = ref();
+const isActive = computed(() => item.index === parent.value.activeIndex);
 
-const isActive = computed(() => item.value.index === parent.value.activeIndex);
-
+const transitionName = ref<string>();
 const isTransitioning = ref(false);
 
 const nextAnimation = computed(() => {
@@ -97,33 +102,35 @@ const prevAnimation = computed(() => {
 
 const itemVariant = computed(() => parent.value.variant ?? props.variant);
 
-/** shows if the step is clickable or not */
-const isClickable = computed(
+/** Shows if the item is clickable or not. */
+// strongly type this variable to prevent circular type dependency
+// because `parent` is used inside and the variable is used by the parent
+const isClickable: ComputedRef<boolean> = computed(
     () =>
         !props.disabled &&
-        (props.clickable || item.value.index < parent.value.activeIndex),
+        (props.clickable || item.index < parent.value.activeIndex),
 );
 
 /** Activate element, alter animation name based on the index. */
 function activate(oldIndex: number): void {
     transitionName.value =
-        item.value.index < oldIndex ? nextAnimation.value : prevAnimation.value;
+        item.index < oldIndex ? nextAnimation.value : prevAnimation.value;
     emits("activate");
 }
 
 /** Deactivate element, alter animation name based on the index. */
 function deactivate(newIndex: number): void {
     transitionName.value =
-        newIndex < item.value.index ? nextAnimation.value : prevAnimation.value;
+        newIndex < item.index ? nextAnimation.value : prevAnimation.value;
     emits("deactivate");
 }
 
-/** Transition after-enter hook */
+/** Transition after-enter hook. */
 function afterEnter(): void {
     isTransitioning.value = true;
 }
 
-/** Transition before-leave hook */
+/** Transition before-leave hook. */
 function beforeLeave(): void {
     isTransitioning.value = true;
 }
@@ -159,13 +166,13 @@ const stepClasses: Ref<ClassBinding[]> = defineClasses(
         "stepPreviousClass",
         "o-steps__step--previous",
         null,
-        computed(() => item.value.index < parent.value?.activeIndex),
+        computed(() => item.index < parent.value?.activeIndex),
     ],
     [
         "stepNextClass",
         "o-steps__step--next",
         null,
-        computed(() => item.value.index > parent.value?.activeIndex),
+        computed(() => item.index > parent.value?.activeIndex),
     ],
 );
 

--- a/packages/oruga/src/components/steps/types.ts
+++ b/packages/oruga/src/components/steps/types.ts
@@ -14,7 +14,10 @@ export type StepsComponent = {
     animateInitially: boolean;
 };
 
-export type StepItemComponent<T> = StepItemProps<T, Component> & {
+export type StepItemComponent<T> = Pick<
+    StepItemProps<T, Component>,
+    "value" | "label" | "step" | "disabled" | "visible" | "icon" | "iconPack"
+> & {
     $slots: Slots;
     stepClasses: ClassBinding[];
     iconClasses: ClassBinding[];
@@ -25,4 +28,4 @@ export type StepItemComponent<T> = StepItemProps<T, Component> & {
     deactivate: (index: number) => void;
 };
 
-export type StepItem<T> = Omit<ProviderItem, "data"> & StepItemComponent<T>;
+export type StepItem<T> = ProviderItem<StepItemComponent<T>>;

--- a/packages/oruga/src/components/table/TableColumn.vue
+++ b/packages/oruga/src/components/table/TableColumn.vue
@@ -54,7 +54,7 @@ const providedData = computed<TableColumnComponent<T>>(() => ({
 }));
 
 /** inject functionalities and data from the parent component */
-const { item } = useProviderChild<TableColumnComponent<T>>(rootRef, {
+const { item } = useProviderChild<unknown, TableColumnComponent<T>>(rootRef, {
     data: providedData,
 });
 

--- a/packages/oruga/src/components/tabs/TabItem.vue
+++ b/packages/oruga/src/components/tabs/TabItem.vue
@@ -60,8 +60,13 @@ const slots = useSlots();
 
 // provided data is a computed ref to ensure reactivity
 const providedData = computed<TabItemComponent<T>>(() => ({
-    ...props,
-    value: itemValue,
+    value: itemValue as T,
+    label: props.label,
+    disabled: props.disabled,
+    visible: props.visible,
+    tag: props.tag,
+    icon: props.icon,
+    iconPack: props.iconPack,
     $slots: slots,
     tabClasses: tabClasses.value,
     iconClasses: tabIconClasses.value,
@@ -77,10 +82,9 @@ const { parent, item } = useProviderChild<TabsComponent, TabItemComponent<T>>(
     { data: providedData },
 );
 
-const transitionName = ref();
+const isActive = computed(() => item.index === parent.value.activeIndex);
 
-const isActive = computed(() => item.value.index === parent.value.activeIndex);
-
+const transitionName = ref<string>();
 const isTransitioning = ref(false);
 
 const nextAnimation = computed(() => {
@@ -100,23 +104,23 @@ const itemVariant = computed(() => props.variant ?? parent.value.variant);
 /** Activate element, alter animation name based on the index. */
 function activate(oldIndex: number): void {
     transitionName.value =
-        item.value.index < oldIndex ? nextAnimation.value : prevAnimation.value;
+        item.index < oldIndex ? nextAnimation.value : prevAnimation.value;
     emits("activate");
 }
 
 /** Deactivate element, alter animation name based on the index. */
 function deactivate(newIndex: number): void {
     transitionName.value =
-        newIndex < item.value.index ? nextAnimation.value : prevAnimation.value;
+        newIndex < item.index ? nextAnimation.value : prevAnimation.value;
     emits("deactivate");
 }
 
-/** Transition after-enter hook */
+/** Transition after-enter hook. */
 function afterEnter(): void {
     isTransitioning.value = true;
 }
 
-/** Transition before-leave hook */
+/** Transition before-leave hook. */
 function beforeLeave(): void {
     isTransitioning.value = true;
 }
@@ -145,13 +149,13 @@ const tabClasses: Ref<ClassBinding[]> = defineClasses(
         "tabPreviousClass",
         "o-tabs__tab--previous",
         null,
-        computed(() => item.value.index < parent.value?.activeIndex),
+        computed(() => item.index < parent.value?.activeIndex),
     ],
     [
         "tabNextClass",
         "o-tabs__tab--next",
         null,
-        computed(() => item.value.index > parent.value?.activeIndex),
+        computed(() => item.index > parent.value?.activeIndex),
     ],
 );
 

--- a/packages/oruga/src/components/tabs/Tabs.vue
+++ b/packages/oruga/src/components/tabs/Tabs.vue
@@ -4,7 +4,6 @@ import {
     ref,
     watch,
     watchEffect,
-    toValue,
     nextTick,
     onMounted,
     useTemplateRef,
@@ -93,19 +92,9 @@ const provideData = computed<TabsComponent>(() => ({
 }));
 
 /** provide functionalities and data to child item components */
-const { childItems } = useProviderParent<TabItemComponent<T>>({
+const { childItems, itemsCount } = useProviderParent<TabItemComponent<T>>({
     rootRef,
     data: provideData,
-});
-
-const items = computed<TabItem<T>[]>(() => {
-    if (!childItems.value) return [];
-    return childItems.value.map((column) => ({
-        el: column.el,
-        index: column.index,
-        identifier: column.identifier,
-        ...toValue(column.data!),
-    }));
 });
 
 // create a unique id sequence
@@ -116,14 +105,21 @@ const normalizedOptions = computed(() =>
     normalizeOptions<T>(props.options, nextSequence),
 );
 
+// #region --- Active Item Feature ---
+
 /** The selected item value, use v-model to make it two-way binding */
 const vmodel = defineModel<ModelValue>({ default: undefined });
 
-/**  When v-model is changed set the new active tab. */
+onMounted(() => {
+    // set first tab as default if not defined
+    if (!vmodel.value) vmodel.value = childItems.value[0]?.data.value;
+});
+
+/** When v-model is changed set the new active tab. */
 watch(
     () => props.modelValue,
     (value) => {
-        if (vmodel.value !== value) performAction(value as T);
+        if (vmodel.value !== value) activateItem(value);
     },
 );
 
@@ -133,25 +129,42 @@ const activeItem = ref<TabItem<T>>();
 // set the active item immediate and every time the vmodel changes
 watchEffect(() => {
     activeItem.value = isDefined(vmodel.value)
-        ? items.value.find((item) => item.value === vmodel.value) ||
-          items.value[0]
-        : items.value[0];
+        ? childItems.value.find((item) => item.data.value === vmodel.value) ||
+          childItems.value[0]
+        : childItems.value[0];
 });
 
 const isTransitioning = computed(() =>
-    items.value.some((item) => item.isTransitioning),
+    childItems.value.some((item) => item.data.isTransitioning),
 );
 
-onMounted(() => {
-    // set first tab as default if not defined
-    if (!vmodel.value) vmodel.value = items.value[0]?.value;
-});
+/** Activate a specific child item by value and deactivate the previous child item. */
+function activateItem(newValue: ModelValue): void {
+    const oldValue = activeItem.value?.data.value;
+    const oldItem = activeItem.value;
+    const newItem =
+        childItems.value.find((item) => item.data.value === newValue) ||
+        childItems.value[0];
 
-// --- EVENT HANDLER ---
+    if (oldItem?.data && newItem?.data) {
+        oldItem.data.deactivate(newItem.index);
+        newItem.data.activate(oldItem.index);
+    }
 
-/** Tab item click listener, emit input event and change active child. */
+    nextTick(() => {
+        vmodel.value = newValue;
+        emits("change", newValue, oldValue);
+    });
+}
+
+// #endregion --- Active Item Feature ---
+
+// #region --- Event Handler ---
+
+/** Item click listener, emit input event and change active child. */
 function itemClick(item: TabItem<T>): void {
-    if (vmodel.value !== item.value) performAction(item.value);
+    if (!item.data || vmodel.value === item.data.value) return;
+    activateItem(item.data.value);
 }
 
 /** Focus the next item or wrap around. */
@@ -160,9 +173,9 @@ function onNext(event: KeyboardEvent, index: number): void {
         (props.vertical && event.key == "ArrowDown") ||
         (!props.vertical && event.key == "ArrowRight")
     ) {
-        const newIndex = mod(index + 1, items.value.length);
+        const newIndex = mod(index + 1, itemsCount.value);
         const item = getFirstViableItem(newIndex, true);
-        moveFocus(item);
+        if (isDefined(item)) moveFocus(item);
     }
 }
 
@@ -172,24 +185,24 @@ function onPrev(event: KeyboardEvent, index: number): void {
         (props.vertical && event.key == "ArrowUp") ||
         (!props.vertical && event.key == "ArrowLeft")
     ) {
-        const newIndex = mod(index - 1, items.value.length);
+        const newIndex = mod(index - 1, itemsCount.value);
         const item = getFirstViableItem(newIndex, false);
-        moveFocus(item);
+        if (isDefined(item)) moveFocus(item);
     }
 }
 
 /** Focus to the first viable item. */
 function onHomePressed(): void {
-    if (items.value.length < 1) return;
+    if (itemsCount.value < 1) return;
     const item = getFirstViableItem(0, true);
-    moveFocus(item);
+    if (isDefined(item)) moveFocus(item);
 }
 
 /** Focus to the last viable item. */
 function onEndPressed(): void {
-    if (items.value.length < 1) return;
-    const item = getFirstViableItem(items.value.length - 1, false);
-    moveFocus(item);
+    if (itemsCount.value < 1) return;
+    const item = getFirstViableItem(itemsCount.value - 1, false);
+    if (isDefined(item)) moveFocus(item);
 }
 
 /** Set focus on a tab item or click it if `activateOnFocus`. */
@@ -219,35 +232,17 @@ function getFirstViableItem(
     for (
         ;
         newIndex !== activeItem.value?.index;
-        newIndex = mod(newIndex + direction, items.value.length)
+        newIndex = mod(newIndex + direction, itemsCount.value)
     ) {
+        const item = childItems.value[newIndex];
         // Break if the item at this index is viable (not disabled and is visible)
-        if (items.value[newIndex].visible && !items.value[newIndex].disabled)
-            break;
+        if (item.data.visible && !item.data.disabled) break;
     }
 
-    return items.value[newIndex];
+    return childItems.value[newIndex];
 }
 
-/** Activate next child and deactivate prev child. */
-function performAction(newValue: ModelValue): void {
-    const oldValue = vmodel.value;
-    const oldItem = activeItem.value;
-    const newItem =
-        items.value.find((item) => item.value === newValue) || items.value[0];
-
-    if (oldItem && newItem) {
-        oldItem.deactivate(newItem.index);
-        newItem.activate(oldItem.index);
-    }
-
-    nextTick(() => {
-        vmodel.value = newValue;
-        emits("change", newValue, oldValue);
-    });
-}
-
-// --- Computed Component Classes ---
+// #region --- Computed Component Classes ---
 
 const rootClasses = defineClasses(
     ["rootClass", "o-tabs"],
@@ -290,6 +285,8 @@ const contentClasses = defineClasses(
         isTransitioning,
     ],
 );
+
+// #endregion --- Computed Component Classes ---
 </script>
 
 <template>
@@ -306,38 +303,40 @@ const contentClasses = defineClasses(
             <slot name="before" />
 
             <o-slot-component
-                v-for="childItem in items"
-                v-show="childItem.visible"
-                :id="`tab-${childItem.identifier}`"
-                :key="childItem.identifier"
-                :component="childItem"
-                :tag="childItem.tag"
+                v-for="item in childItems"
+                v-show="item.data.visible"
+                :id="`tab-${item.identifier}`"
+                :key="item.identifier"
+                :component="item.data"
+                :tag="item.data.tag"
                 name="header"
-                :class="childItem.tabClasses"
+                :class="item.data.tabClasses"
                 role="tab"
-                :tabindex="childItem.value === activeItem?.value ? 0 : -1"
+                :tabindex="item.data.value === activeItem?.data.value ? 0 : -1"
                 :aria-current="
-                    childItem.value === activeItem?.value ? 'true' : undefined
+                    item.data.value === activeItem?.data.value
+                        ? 'true'
+                        : undefined
                 "
-                :aria-controls="`tabpanel-${childItem.identifier}`"
-                :aria-selected="childItem.value === activeItem?.value"
-                @click="itemClick(childItem)"
-                @keydown.enter.prevent="itemClick(childItem)"
-                @keydown.space.prevent="itemClick(childItem)"
-                @keydown.left.prevent="onPrev($event, childItem.index)"
-                @keydown.right.prevent="onNext($event, childItem.index)"
-                @keydown.up.prevent="onPrev($event, childItem.index)"
-                @keydown.down.prevent="onNext($event, childItem.index)"
+                :aria-controls="`tabpanel-${item.identifier}`"
+                :aria-selected="item.data.value === activeItem?.data.value"
+                @click="itemClick(item)"
+                @keydown.enter.prevent="itemClick(item)"
+                @keydown.space.prevent="itemClick(item)"
+                @keydown.left.prevent="onPrev($event, item.index)"
+                @keydown.right.prevent="onNext($event, item.index)"
+                @keydown.up.prevent="onPrev($event, item.index)"
+                @keydown.down.prevent="onNext($event, item.index)"
                 @keydown.home.prevent="onHomePressed"
                 @keydown.end.prevent="onEndPressed">
                 <o-icon
-                    v-if="childItem.icon"
-                    :class="childItem.iconClasses"
-                    :icon="childItem.icon"
-                    :pack="childItem.iconPack"
+                    v-if="item.data.icon"
+                    :class="item.data.iconClasses"
+                    :icon="item.data.icon"
+                    :pack="item.data.iconPack"
                     :size="size" />
-                <span :class="childItem.labelClasses">
-                    {{ childItem.label }}
+                <span :class="item.data.labelClasses">
+                    {{ item.data.label }}
                 </span>
             </o-slot-component>
 

--- a/packages/oruga/src/components/tabs/examples/base.vue
+++ b/packages/oruga/src/components/tabs/examples/base.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref } from "vue";
 
-const activeTab = ref(0);
+const activeTab = ref<string>();
 const showBooks = ref(false);
 </script>
 
@@ -10,20 +10,20 @@ const showBooks = ref(false);
         <o-field grouped>
             <o-switch v-model="showBooks" label="Show Books item" />
 
-            <o-button label="Set Music" @click="activeTab = 2" />
+            <o-button label="Set Music" @click="activeTab = 'music'" />
         </o-field>
 
         <o-tabs v-model="activeTab">
-            <o-tab-item :value="0" label="Pictures" icon="image">
+            <o-tab-item value="pictures" label="Pictures" icon="image">
                 what light is light, if Silvia be not seen? <br />
                 What joy is joy.
             </o-tab-item>
 
-            <o-tab-item :value="1" label="Articles" icon="pen">
+            <o-tab-item value="articles" label="Articles" icon="pen">
                 Lorem ipsum dolor sit amet.
             </o-tab-item>
 
-            <o-tab-item :value="2" label="Music" icon="music">
+            <o-tab-item value="music" label="Music" icon="music">
                 Lorem <br />
                 ipsum <br />
                 dolor <br />
@@ -32,7 +32,7 @@ const showBooks = ref(false);
             </o-tab-item>
 
             <o-tab-item
-                :value="3"
+                value="books"
                 :visible="showBooks"
                 label="Books"
                 icon="book">
@@ -44,7 +44,7 @@ const showBooks = ref(false);
                 There is no music in the nightingale.
             </o-tab-item>
 
-            <o-tab-item :value="4" label="Words">
+            <o-tab-item value="words" label="Words">
                 This text is much longer than the other examples. The most
                 merciful thing in the world, I think, is the inability of the
                 human mind to correlate all its contents. We live on a placid
@@ -58,7 +58,7 @@ const showBooks = ref(false);
                 safety of a new dark age.
             </o-tab-item>
 
-            <o-tab-item :value="5" label="Videos" icon="video" disabled>
+            <o-tab-item value="videos" label="Videos" icon="video" disabled>
                 Nunc nec velit nec libero vestibulum eleifend. Curabitur
                 pulvinar congue luctus. Nullam hendrerit iaculis augue vitae
                 ornare. Maecenas vehicula pulvinar tellus, id sodales felis

--- a/packages/oruga/src/components/tabs/types.ts
+++ b/packages/oruga/src/components/tabs/types.ts
@@ -14,7 +14,10 @@ export type TabsComponent = {
     animateInitially: boolean;
 };
 
-export type TabItemComponent<T> = TabItemProps<T, Component> & {
+export type TabItemComponent<T> = Pick<
+    TabItemProps<T, Component>,
+    "value" | "label" | "disabled" | "visible" | "tag" | "icon" | "iconPack"
+> & {
     $slots: Slots;
     tabClasses: ClassBinding[];
     iconClasses: ClassBinding[];
@@ -24,4 +27,4 @@ export type TabItemComponent<T> = TabItemProps<T, Component> & {
     deactivate: (index: number) => void;
 };
 
-export type TabItem<T> = Omit<ProviderItem<T>, "data"> & TabItemComponent<T>;
+export type TabItem<T> = ProviderItem<TabItemComponent<T>>;


### PR DESCRIPTION
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- add a `itemsCount` attribute to the `useProviderParent` and `useProviderChild` composable return value
- remove any unused props from the child item data to prevent unnecessary recomputation of the computed data property when an unused prop changes
- remove the unnecessary ref wrapper of the `useProviderChild` item element
