### PR TITLE
fix(carousel): solve tab navigation issues when has no indicators

### DIFF
--- a/packages/oruga/src/components/carousel/examples/slideshow.vue
+++ b/packages/oruga/src/components/carousel/examples/slideshow.vue
@@ -85,7 +85,9 @@ function switchGalleryOff(event: KeyboardEvent): void {
                     :model-value="activeIndex"
                     :indicators="false"
                     :breakpoints="breakpoints"
-                    @update:model-value="switchTo($event)">
+                    @update:model-value="switchTo($event)"
+                    @keydown.left.stop
+                    @keydown.right.stop>
                     <o-carousel-item
                         v-for="slide in slides"
                         :key="slide.title"

--- a/packages/oruga/src/components/carousel/props.ts
+++ b/packages/oruga/src/components/carousel/props.ts
@@ -73,31 +73,31 @@ export type CarouselClasses = Partial<{
     overlayClass: ComponentClass;
     /** Class of the inner wrapper element */
     wrapperClass: ComponentClass;
-    /** Class of items container element */
+    /** Class of the items container element */
     itemsClass: ComponentClass;
-    /* Class of items container element when dragging */
+    /** Class of the items container element when dragging */
     itemsDraggingClass: ComponentClass;
-    /** Class of icon button elements */
+    /** Class of the icon button elements */
     iconClass: ComponentClass;
-    /** Class of prev icon button element */
+    /** Class of the prev icon button element */
     iconPrevClass: ComponentClass;
-    /** Class of next icon button element */
+    /** Class of the next icon button element */
     iconNextClass: ComponentClass;
-    /** Class of autoplay icon button element */
+    /** Class of the autoplay icon button element */
     iconAutoplayClass: ComponentClass;
-    /** Class of indicators tablist element */
+    /** Class of the indicators tablist element */
     indicatorsClass: ComponentClass;
-    /** Class of indicators tablist element when inside */
+    /** Class of the indicators tablist element when inside */
     indicatorsInsideClass: ComponentClass;
-    /** Class of indicators tablist element with position */
+    /** Class of the indicators tablist element with position */
     indicatorsPositionClass: ComponentClass;
-    /** Class of indicator tab element */
+    /** Class of the indicator tab element */
     indicatorClass: ComponentClass;
-    /** Class of indicator item element */
+    /** Class of the indicator item element */
     indicatorItemClass: ComponentClass;
-    /** Class of indicator element when active */
+    /** Class of the indicator element when active */
     indicatorItemActiveClass: ComponentClass;
-    /** Class of indicator element to separate different styles */
+    /** Class of the indicator element to separate different styles */
     indicatorItemStyleClass: ComponentClass;
 }>;
 

--- a/packages/oruga/src/components/types.ts
+++ b/packages/oruga/src/components/types.ts
@@ -232,31 +232,31 @@ In addition, any CSS selector string or an actual DOM node can be used. */
                 overlayClass: ClassDefinition;
                 /** Class of the inner wrapper element */
                 wrapperClass: ClassDefinition;
-                /** Class of items container element */
+                /** Class of the items container element */
                 itemsClass: ClassDefinition;
-                /**  */
+                /** Class of the items container element when dragging */
                 itemsDraggingClass: ClassDefinition;
-                /** Class of icon button elements */
+                /** Class of the icon button elements */
                 iconClass: ClassDefinition;
-                /** Class of prev icon button element */
+                /** Class of the prev icon button element */
                 iconPrevClass: ClassDefinition;
-                /** Class of next icon button element */
+                /** Class of the next icon button element */
                 iconNextClass: ClassDefinition;
-                /** Class of autoplay icon button element */
+                /** Class of the autoplay icon button element */
                 iconAutoplayClass: ClassDefinition;
-                /** Class of indicators tablist element */
+                /** Class of the indicators tablist element */
                 indicatorsClass: ClassDefinition;
-                /** Class of indicators tablist element when inside */
+                /** Class of the indicators tablist element when inside */
                 indicatorsInsideClass: ClassDefinition;
-                /** Class of indicators tablist element with position */
+                /** Class of the indicators tablist element with position */
                 indicatorsPositionClass: ClassDefinition;
-                /** Class of indicator tab element */
+                /** Class of the indicator tab element */
                 indicatorClass: ClassDefinition;
-                /** Class of indicator item element */
+                /** Class of the indicator item element */
                 indicatorItemClass: ClassDefinition;
-                /** Class of indicator element when active */
+                /** Class of the indicator element when active */
                 indicatorItemActiveClass: ClassDefinition;
-                /** Class of indicator element to separate different styles */
+                /** Class of the indicator element to separate different styles */
                 indicatorItemStyleClass: ClassDefinition;
                 /** Class of the item element */
                 itemClass: ClassDefinition;


### PR DESCRIPTION
## Proposed Changes

- make carousel slide wrapper tabable when no indicators are available
