### PR TITLE
chore(carousel): remove outdated TODO comments

### DIFF
--- a/packages/oruga/package.json
+++ b/packages/oruga/package.json
@@ -56,7 +56,7 @@
     "build": "rimraf dist && vite build && vite build --mode minify",
     "build:watch": "vite build --mode minify --watch",
     "build:lib": "rimraf dist && npm run test:ts && npm run build",
-    "build:lib:watch": "npm link && npm run build:watch",
+    "build:lib:watch": "(npm link || true) && npm run build:watch",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:ts": "vue-tsc --noEmit --skipLibCheck --project tsconfig.app.json",

--- a/packages/oruga/src/components/carousel/Carousel.vue
+++ b/packages/oruga/src/components/carousel/Carousel.vue
@@ -48,13 +48,6 @@ defineOptions({
 
 type ModelValue = CarouselProps<T>["modelValue"];
 
-/**
- *
- * TODO: add options example
- * TODO: add options tests
- *
- */
-
 const props = withDefaults(defineProps<CarouselProps<T>>(), {
     override: undefined,
     modelValue: undefined,

--- a/packages/oruga/src/components/listbox/props.ts
+++ b/packages/oruga/src/components/listbox/props.ts
@@ -92,7 +92,7 @@ export type ListItemProps<T> = {
      */
     value?: T;
     /** Item label, unnecessary when default slot is used */
-    label?: string; // TODO: make requried
+    label?: string; // TODO: make required
     /** Item is disabled */
     disabled?: boolean;
     /** Define whether the item is visible or not */

--- a/packages/oruga/src/components/tree/props.ts
+++ b/packages/oruga/src/components/tree/props.ts
@@ -74,7 +74,7 @@ export type TreeItemProps<T> = {
     /** Subtree items, unnecessary when default slot is used */
     options?: OptionsProp<T>;
     /** Tree item label */
-    label?: string; // TODO: make requried
+    label?: string; // TODO: make required
     /** Tree item will be expanded */
     expanded?: boolean;
     /** Tree item will be disabled */


### PR DESCRIPTION
- Remove TODO comments for options example and tests (already implemented)
- Fix typo: requried → required in tree and listbox props
- Make npm link optional in build:lib:watch script

<!-- Thank you for helping Oruga! -->

## Proposed Changes

- Remove outdated TODO comments from Carousel component (options example and tests already exist)
- Fix typo: "requried" → "required" in tree and listbox props
- Make npm link optional in build:lib:watch script for better developer experience

## Why

These are simple code cleanup tasks that improve code quality:
1. The TODO comments in Carousel.vue were outdated - the options example and tests already exist
2. Fixed a typo in comments ("requried" → "required") for better readability
3. The npm link fix allows the build to continue even without global npm permissions, improving the developer experience

