### PR TITLE
fix(pagination): pass `iconPack` property correctly to the internal button components

### DIFF
--- a/packages/oruga/src/components/pagination/Pagination.vue
+++ b/packages/oruga/src/components/pagination/Pagination.vue
@@ -352,7 +352,7 @@ defineExpose({ last: onLast, first: onFirst, prev: onPrev, next: onNext });
                 :label="undefined"
                 :disabled="isFirst || disabled"
                 :icon-left="iconPrev"
-                :pack="iconPack"
+                :icon-pack="iconPack"
                 :rounded="rounded"
                 :size="size"
                 :class="[...buttonBaseClasses, ...buttonPrevClasses]" />
@@ -365,7 +365,7 @@ defineExpose({ last: onLast, first: onFirst, prev: onPrev, next: onNext });
                 :label="undefined"
                 :disabled="isLast || disabled"
                 :icon-left="iconNext"
-                :pack="iconPack"
+                :icon-pack="iconPack"
                 :rounded="rounded"
                 :size="size"
                 :class="[...buttonBaseClasses, ...buttonNextClasses]" />


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #1516

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- The `iconPack` property was not being passed correctly to the OButton component used by the OPagination component. I updated the property name to ensure that it is passed correctly.
