### PR TITLE
feat(dialog): add `returnValue` to component emits

### DIFF
--- a/packages/docs/components/Dialog.md
+++ b/packages/docs/components/Dialog.md
@@ -75,27 +75,27 @@ The component implements the W3C ARIA APG [Dialog (Modal) Pattern](https://www.w
 
 ### Events
 
-| Event name    | Properties                                | Description                                                              |
-| ------------- | ----------------------------------------- | ------------------------------------------------------------------------ |
-| update:active | **value** `boolean` - updated active prop | active prop two-way binding                                              |
-| close         | **event** `Event` - native event          | the event is fired when the dialog has been closed                       |
-| cancel        | **event** `Event` - native event          | the event is fired when the user wish to dismiss the current open dialog |
-| confirm       | **event** `Event` - native event          | the event is fired when the confirm button get clicked                   |
+| Event name    | Properties                                                                                      | Description                                                              |
+| ------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| update:active | **value** `boolean` - updated active prop                                                       | active prop two-way binding                                              |
+| close         | **event** `Event` - native event<br/>**value** `String \| undefined` - an optional return value | the event is fired when the dialog has been closed                       |
+| cancel        | **event** `Event` - native event<br/>**value** `String \| undefined` - an optional return value | the event is fired when the user wish to dismiss the current open dialog |
+| confirm       |                                                                                                 | the event is fired when the confirm button get clicked                   |
 
 ### Slots
 
-| Name          | Description                                            | Bindings                                                                                                                                        |
-| ------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| header        | Override the header                                    | **close** `(event: Event): void` - function to emit a `close` event                                                                             |
-| title         | Override the header title, default is title prop       |                                                                                                                                                 |
-| subtitle      | Override the header subtitle, default is subtitle prop |                                                                                                                                                 |
-| close         | Define a custom close icon                             |                                                                                                                                                 |
-| image         | Override the image element                             |                                                                                                                                                 |
-| default       | Override the default dialog body                       | **close** `(event: Event): void` - function to emit a `close` event<br/>**confirm** `(event: Event): void` - function to emit a `confirm` event |
-| content       | Override the body content, default is content prop     | **close** `(event: Event): void` - function to emit a `close` event<br/>**confirm** `(event: Event): void` - function to emit a `confirm` event |
-| footer        | Override the footer                                    | **close** `(event: Event): void` - function to emit a `close` event<br/>**confirm** `(event: Event): void` - function to emit a `confirm` event |
-| cancelButton  | Define the cancel button label                         |                                                                                                                                                 |
-| confirmButton | Define the confirm button label                        |                                                                                                                                                 |
+| Name          | Description                                            | Bindings                                                                                                                                    |
+| ------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| header        | Override the header                                    | **close** `(returnValue?: string): void` - function to emit a `close` event<br/>**confirm** `(): void` - function to emit a `confirm` event |
+| title         | Override the header title, default is title prop       |                                                                                                                                             |
+| subtitle      | Override the header subtitle, default is subtitle prop |                                                                                                                                             |
+| close         | Define a custom close icon                             |                                                                                                                                             |
+| image         | Override the image element                             |                                                                                                                                             |
+| default       | Override the default dialog body                       | **close** `(returnValue?: string): void` - function to emit a `close` event<br/>**confirm** `(): void` - function to emit a `confirm` event |
+| content       | Override the body content, default is content prop     | **close** `(returnValue?: string): void` - function to emit a `close` event<br/>**confirm** `(): void` - function to emit a `confirm` event |
+| footer        | Override the footer                                    | **close** `(returnValue?: string): void` - function to emit a `close` event<br/>**confirm** `(): void` - function to emit a `confirm` event |
+| cancelButton  | Define the cancel button label                         |                                                                                                                                             |
+| confirmButton | Define the confirm button label                        |                                                                                                                                             |
 
 </section>
 

--- a/packages/oruga/src/components/dialog/Dialog.vue
+++ b/packages/oruga/src/components/dialog/Dialog.vue
@@ -179,7 +179,10 @@ const hasBackdrop = computed(
     () => props.backdrop || props.alert || rootRef.value?.ariaModal,
 );
 
-/** Specifies the types of user actions that can be used to close the dialog. */
+/**
+ * Specifies the types of user actions that can be used to close the dialog.
+ * See https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#closedby
+ */
 const closedBy = computed(() => {
     // The dialog can be dismissed when the user clicks or taps outside it,
     // and with a platform-specific user action or a developer-specified mechanism.
@@ -228,7 +231,7 @@ onMounted(() => toggleDialog(isActive.value));
 
 watch(isActive, toggleDialog);
 
-/** show of close the dialog element */
+/** show or close the dialog element */
 function toggleDialog(value: boolean): void {
     if (!rootRef.value) return;
 
@@ -247,7 +250,7 @@ function toggleDialog(value: boolean): void {
 }
 
 /** request the dialog to close when active */
-function cancel(returnValue?: string): void {
+function close(returnValue?: string): void {
     if (!isActive.value || !rootRef.value) return;
 
     // trigger dialog close event
@@ -257,7 +260,7 @@ function cancel(returnValue?: string): void {
     else rootRef.value.close(returnValue);
 }
 
-/** confirm button click event */
+/** emit a confirm event when active */
 function confirm(): void {
     if (!isActive.value || !rootRef.value) return;
 
@@ -359,7 +362,7 @@ const cancelButtonClasses = defineClasses([
 // #region --- Expose Public Functionalities ---
 
 /** expose functionalities for programmatic usage */
-defineExpose({ close: cancel });
+defineExpose({ close, confirm });
 
 // #endregion --- Expose Public Functionalities ---
 </script>
@@ -396,7 +399,7 @@ defineExpose({ close: cancel });
                             closeable
                         "
                         :class="headerClasses">
-                        <slot name="header" :close="cancel" :confirm="confirm">
+                        <slot name="header" :close="close" :confirm="confirm">
                             <h1
                                 v-if="$slots['title'] || title"
                                 :id="titleId"
@@ -418,7 +421,7 @@ defineExpose({ close: cancel });
                             :size="closeIconSize"
                             :label="ariaCloseLabel"
                             :classes="closeClasses"
-                            @click="cancel">
+                            @click="close">
                             <slot v-if="$slots['close']" name="close" />
                         </CloseButton>
                     </header>
@@ -443,19 +446,19 @@ defineExpose({ close: cancel });
                         </slot>
 
                         <!-- Main Content -->
-                        <slot :close="cancel" :confirm="confirm">
+                        <slot :close="close" :confirm="confirm">
                             <!-- injected component for programmatic usage -->
                             <component
                                 :is="$props.component"
                                 v-if="$props.component"
                                 v-bind="$props.props"
                                 v-on="$props.events || {}"
-                                @close="cancel" />
+                                @close="close" />
 
                             <p v-else :class="contentClasses">
                                 <slot
                                     name="content"
-                                    :close="cancel"
+                                    :close="close"
                                     :confirm="confirm">
                                     {{ content }}
                                 </slot>
@@ -474,7 +477,7 @@ defineExpose({ close: cancel });
                     <footer
                         v-if="$slots['footer'] || cancelButton || confirmButton"
                         :class="footerClasses">
-                        <slot name="footer" :close="cancel" :confirm="confirm">
+                        <slot name="footer" :close="close" :confirm="confirm">
                             <OButton
                                 v-if="cancelButton || $slots['cancelButton']"
                                 ref="cancelButton"
@@ -483,7 +486,7 @@ defineExpose({ close: cancel });
                                 :variant="cancelVariant"
                                 :disabled="disableCancel"
                                 autofocus
-                                @click="cancel('cancel')"
+                                @click="close('cancel')"
                                 @keyup.right="focusConfirmButton">
                                 <slot name="cancelButton">
                                     {{ cancelButton }}

--- a/packages/oruga/src/components/dialog/Dialog.vue
+++ b/packages/oruga/src/components/dialog/Dialog.vue
@@ -87,26 +87,31 @@ const emits = defineEmits<{
     /**
      * the event is fired when the dialog has been closed
      * @param event {Event} - native event
+     * @param value {String | undefined} - an optional return value
      */
-    close: [event: Event];
+    close: [event: Event, value?: string];
     /**
      * the event is fired when the user wish to dismiss the current open dialog
      * @param event {Event} - native event
+     * @param value {String | undefined} - an optional return value
      */
-    cancel: [event: Event];
+    cancel: [event: Event, value?: string];
     /**
      * the event is fired when the confirm button get clicked
-     * @param event {Event} native event
      */
-    confirm: [event: Event];
+    confirm: [];
 }>();
 
 defineSlots<{
     /**
      * Override the header
-     * @param close {(event: Event): void} - function to emit a `close` event
+     * @param close {(returnValue?: string): void} - function to emit a `close` event
+     * @param confirm {(): void} - function to emit a `confirm` event
      */
-    header?(props: { close: (event: Event) => void }): void;
+    header?(props: {
+        close: (returnValue?: string) => void;
+        confirm: () => void;
+    }): void;
     /** Override the header title, default is title prop */
     title?(): void;
     /** Override the header subtitle, default is subtitle prop */
@@ -117,30 +122,30 @@ defineSlots<{
     image?(): void;
     /**
      * Override the default dialog body
-     * @param close {(event: Event): void} - function to emit a `close` event
-     * @param confirm {(event: Event): void} - function to emit a `confirm` event
+     * @param close {(returnValue?: string): void} - function to emit a `close` event
+     * @param confirm {(): void} - function to emit a `confirm` event
      */
     default?(props: {
-        close: (event: Event) => void;
-        confirm: (event: Event) => void;
+        close: (returnValue?: string) => void;
+        confirm: () => void;
     }): void;
     /**
      * Override the body content, default is content prop
-     * @param close {(event: Event): void} - function to emit a `close` event
-     * @param confirm {(event: Event): void} - function to emit a `confirm` event
+     * @param close {(returnValue?: string): void} - function to emit a `close` event
+     * @param confirm {(): void} - function to emit a `confirm` event
      */
     content?(props: {
-        close: (event: Event) => void;
-        confirm: (event: Event) => void;
+        close: (returnValue?: string) => void;
+        confirm: () => void;
     }): void;
     /**
      * Override the footer
-     * @param close {(event: Event): void} - function to emit a `close` event
-     * @param confirm {(event: Event): void} - function to emit a `confirm` event
+     * @param close {(returnValue?: string): void} - function to emit a `close` event
+     * @param confirm {(): void} - function to emit a `confirm` event
      */
     footer?(props: {
-        close: (event: Event) => void;
-        confirm: (event: Event) => void;
+        close: (returnValue?: string) => void;
+        confirm: () => void;
     }): void;
     /** Define the cancel button label */
     cancelButton?(): void;
@@ -225,11 +230,16 @@ watch(isActive, toggleDialog);
 
 /** show of close the dialog element */
 function toggleDialog(value: boolean): void {
+    if (!rootRef.value) return;
+
     if (value) {
+        // reset the return value on each open
+        rootRef.value.returnValue = "";
+
         // trigger dialog show as modal with backdrop event
-        if (hasBackdrop.value) rootRef.value?.showModal();
+        if (hasBackdrop.value) rootRef.value.showModal();
         // trigger dialog show without backdrop event
-        else rootRef.value?.show();
+        else rootRef.value.show();
     } else if (rootRef.value?.open) {
         // trigger dialog close event
         rootRef.value.close();
@@ -237,35 +247,35 @@ function toggleDialog(value: boolean): void {
 }
 
 /** request the dialog to close when active */
-function cancel(): void {
+function cancel(returnValue?: string): void {
     if (!isActive.value || !rootRef.value) return;
 
-    // dialog.requestClose() is not suported in es2020
     // trigger dialog close event
-    // if (typeof rootRef.value.requestClose === "function")
-    //     // requestClose is a fairly new web API that is not yet supported in all environments
-    //     rootRef.value.requestClose();
-    // else
-    rootRef.value.close();
+    if (typeof rootRef.value.requestClose === "function")
+        // requestClose is a fairly new web API that is not yet supported in all environments
+        rootRef.value.requestClose(returnValue);
+    else rootRef.value.close(returnValue);
 }
 
 /** confirm button click event */
-function confirm(event: Event): void {
+function confirm(): void {
     if (!isActive.value || !rootRef.value) return;
 
-    emits("confirm", event);
-    if (props.closeOnConfirm) rootRef.value.close();
+    emits("confirm");
+    if (props.closeOnConfirm) rootRef.value.close("confirm");
 }
 
 /** native dialog close event */
 function onClose(event: Event): void {
     isActive.value = false;
-    emits("close", event);
+    const returnValue = rootRef.value?.returnValue;
+    emits("close", event, returnValue);
 }
 
 /** native dialog cancel event */
 function onCancel(event: Event): void {
-    emits("cancel", event);
+    const returnValue = rootRef.value?.returnValue;
+    emits("cancel", event, returnValue);
 }
 
 // #endregion --- Trigger Handler ---
@@ -386,7 +396,7 @@ defineExpose({ close: cancel });
                             closeable
                         "
                         :class="headerClasses">
-                        <slot name="header" :close="cancel">
+                        <slot name="header" :close="cancel" :confirm="confirm">
                             <h1
                                 v-if="$slots['title'] || title"
                                 :id="titleId"
@@ -473,7 +483,7 @@ defineExpose({ close: cancel });
                                 :variant="cancelVariant"
                                 :disabled="disableCancel"
                                 autofocus
-                                @click="cancel"
+                                @click="cancel('cancel')"
                                 @keyup.right="focusConfirmButton">
                                 <slot name="cancelButton">
                                     {{ cancelButton }}

--- a/packages/oruga/src/components/dialog/examples/base.vue
+++ b/packages/oruga/src/components/dialog/examples/base.vue
@@ -48,7 +48,7 @@ const isActive = ref(false);
             </template>
 
             <template #footer="{ close }">
-                <o-button label="Close" @click="close" />
+                <o-button label="Close" @click="close()" />
             </template>
         </o-dialog>
     </section>

--- a/packages/oruga/src/components/dialog/examples/form.vue
+++ b/packages/oruga/src/components/dialog/examples/form.vue
@@ -48,8 +48,8 @@ function onLogin(): void {
             </o-field>
 
             <div style="display: flex; align-items: center; gap: 5px">
-                <o-button type="button" label="Close" @click="close" />
-                <o-button label="Login" variant="primary" @click="confirm" />
+                <o-button type="button" label="Close" @click="close()" />
+                <o-button label="Login" variant="primary" @click="confirm()" />
             </div>
         </form>
     </o-dialog>


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #1604

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- use `<dialog>` [`returnValue`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/returnValue) feature to add an optional string argument to the ODialog component emits
