### PR TITLE
fix(tree): correct export component name

### DIFF
--- a/packages/oruga/src/components/tree/index.ts
+++ b/packages/oruga/src/components/tree/index.ts
@@ -18,4 +18,4 @@ export default {
 } satisfies OrugaComponentPlugin;
 
 /** export tree components */
-export { Tree as OTree, TreeItem as OTreItem };
+export { Tree as OTree, TreeItem as OTreeItem };


### PR DESCRIPTION
## Proposed Changes

- The `OTreeItem` component was wrongly exported as `OTreItem` 