### PR TITLE
fix(table): check all preserves previously checked rows if keep-checked is true

### DIFF
--- a/packages/oruga/src/components/table/Table.vue
+++ b/packages/oruga/src/components/table/Table.vue
@@ -867,10 +867,18 @@ function updateCheckedRows(checkAll?: boolean): void {
         // if all rows are already checked, check nothing
         tableCheckedRows.value = [];
     else {
-        // else set all visible rows as checked
-        tableCheckedRows.value = availableRows.value
-            .map((row) => row.value)
-            .filter((value) => props.isRowCheckable(value));
+        // keep previously checked rows from other pages if keepChecked is enabled
+        const previouslyChecked = props.keepChecked
+            ? tableCheckedRows.value
+            : [];
+
+        // set all visible rows as checked
+        tableCheckedRows.value = [
+            ...previouslyChecked,
+            ...availableRows.value
+                .map((row) => row.value)
+                .filter((value) => props.isRowCheckable(value)),
+        ];
     }
 
     // emit event after the reactive checked rows list got updated

--- a/packages/oruga/src/components/table/examples/checkable.vue
+++ b/packages/oruga/src/components/table/examples/checkable.vue
@@ -82,6 +82,7 @@ const columns: TableColumn<(typeof data)[number]>[] = [
 
 const checkboxPosition = ref<"left" | "right">("left");
 const checkedRows = ref([data[1], data[3]]);
+const keepChecked = ref(false);
 </script>
 
 <template>
@@ -97,6 +98,7 @@ const checkedRows = ref([data[1], data[3]]);
                 <option value="left">Checkbox at left</option>
                 <option value="right">Checkbox at right</option>
             </o-select>
+            <o-switch v-model="keepChecked" label="Keep Checked" />
         </o-field>
 
         <o-table
@@ -106,6 +108,7 @@ const checkedRows = ref([data[1], data[3]]);
             row-key="id"
             checkable
             paginated
+            :keep-checked="keepChecked"
             :per-page="5"
             :is-row-checkable="(row) => row.id !== 3 && row.id !== 4"
             :checkbox-position="checkboxPosition">


### PR DESCRIPTION
## Proposed Changes
- Fixes check all  resetting `tableCheckedRows` to only include rows from the current page if `keep-checked` is `true`
- Updates table example, adds `Keep Checked` switch to test the prop

https://github.com/user-attachments/assets/9d0b5d79-3fe4-4c64-9a5c-d71b43f4ed1a

