### PR TITLE
fix(datepicker): show events in prev and next days of a month

### DIFF
--- a/packages/oruga/src/components/datepicker/DatepickerMonth.vue
+++ b/packages/oruga/src/components/datepicker/DatepickerMonth.vue
@@ -310,7 +310,7 @@ function onRangeHoverEndDate(day: Date): void {
     if (isTrueish(props.pickerProps.range)) hoveredEndDate.value = day;
 }
 
-// --- Computed Component Classes ---
+// #region --- Computed Component Classes ---
 
 function dateMatch(dateOne, dateTwo, multiple = false): boolean {
     // if either date is null or undefined, return false
@@ -517,6 +517,8 @@ function eventClasses(event: DatepickerEvent): ClassBinding[] {
     );
     return classes.value;
 }
+
+// #endregion --- Computed Component Classes ---
 </script>
 
 <template>

--- a/packages/oruga/src/components/datepicker/DatepickerTable.vue
+++ b/packages/oruga/src/components/datepicker/DatepickerTable.vue
@@ -66,18 +66,12 @@ const visibleDayNames = computed(() => {
     return visibleDayNames;
 });
 
-/** Return array of all events in the specified month */
-const eventsInThisMonth = computed(() => {
+/** Return array of all events */
+const eventsList = computed(() => {
     if (!props.pickerProps.events) return [];
-    return props.pickerProps.events
-        .map((event) =>
-            !event.date && event instanceof Date ? { date: event } : event,
-        )
-        .filter(
-            (event) =>
-                event.date.getMonth() === focusedDateModel.value.month &&
-                event.date.getFullYear() === focusedDateModel.value.year,
-        );
+    return props.pickerProps.events.map((event) =>
+        !event.date && event instanceof Date ? { date: event } : event,
+    );
 });
 
 /** Return array of all weeks in the specified month */
@@ -105,7 +99,7 @@ const weeksInThisMonth = computed<Date[][]>(() => {
 
 function eventsInThisWeek(week: Date[]): DatepickerEvent[] {
     if (!props.pickerProps.events) return [];
-    return eventsInThisMonth.value.filter((event) => {
+    return eventsList.value.filter((event) => {
         const stripped = new Date(event.date);
         stripped.setHours(0, 0, 0, 0);
         const timed = stripped.getTime();
@@ -234,7 +228,7 @@ function onChangeFocus(date: Date): void {
     };
 }
 
-// --- Computed Component Classes ---
+// #region --- Computed Component Classes ---
 
 const tableClasses = defineClasses(
     ["tableClass", "o-datepicker__table"],
@@ -265,6 +259,8 @@ const tableBodyClasses = defineClasses(
     // passing the picker props will add reactivity to property changes
     { props: props.pickerProps },
 );
+
+// #endregion --- Computed Component Classes ---
 </script>
 
 <template>
@@ -277,6 +273,7 @@ const tableBodyClasses = defineClasses(
                 <span>{{ day }}</span>
             </div>
         </header>
+
         <div :class="tableBodyClasses">
             <o-datepicker-table-row
                 v-for="(week, index) in weeksInThisMonth"

--- a/packages/oruga/src/components/datepicker/DatepickerTableRow.vue
+++ b/packages/oruga/src/components/datepicker/DatepickerTableRow.vue
@@ -36,7 +36,7 @@ const props = defineProps({
         type: [Date, Array] as PropType<Date | Date[]>,
         default: undefined,
     },
-    events: { type: Array as PropType<DatepickerEvent[]>, default: undefined },
+    events: { type: Array as PropType<DatepickerEvent[]>, required: true },
     hoveredDateRange: { type: Array as PropType<Date[]>, required: true },
     pickerProps: {
         type: Object as PropType<DatepickerProps<IsRange, IsMultiple>>,
@@ -55,7 +55,7 @@ const { isDateSelectable, dateCreator } = useDatepickerMixins(
     props.pickerProps,
 );
 
-const hasEvents = computed(() => !!props.events?.length);
+const hasEvents = computed(() => !!props.events.length);
 
 const dayRefs = ref(new Map());
 
@@ -91,7 +91,7 @@ function clickWeekNumber(week: number): void {
     if (props.pickerProps.weekNumberClickable) emits("week-number-click", week);
 }
 
-function getDayOfYear(input): number {
+function getDayOfYear(input: Date): number {
     return (
         Math.round(
             (input.getTime() - new Date(input.getFullYear(), 0, 1).getTime()) /
@@ -100,25 +100,21 @@ function getDayOfYear(input): number {
     );
 }
 
-function getWeekNumber(mom): number {
+function getWeekNumber(day: Date): number {
     const dow = props.pickerProps.firstDayOfWeek; // first day of week
     // Rules for the first week : 1 for the 1st January, 4 for the 4th January
     const doy = props.pickerProps.rulesForFirstWeek;
-    const weekOffset = firstWeekOffset(mom.getFullYear(), dow, doy);
-    const week = Math.floor((getDayOfYear(mom) - weekOffset - 1) / 7) + 1;
-    let resWeek;
-    let resYear;
+    const weekOffset = firstWeekOffset(day.getFullYear(), dow, doy);
+    const week = Math.floor((getDayOfYear(day) - weekOffset - 1) / 7) + 1;
+
     if (week < 1) {
-        resYear = mom.getFullYear() - 1;
-        resWeek = week + weeksInYear(resYear, dow, doy);
-    } else if (week > weeksInYear(mom.getFullYear(), dow, doy)) {
-        resWeek = week - weeksInYear(mom.getFullYear(), dow, doy);
-        resYear = mom.getFullYear() + 1;
+        const resYear = day.getFullYear() - 1;
+        return week + weeksInYear(resYear, dow, doy);
+    } else if (week > weeksInYear(day.getFullYear(), dow, doy)) {
+        return week - weeksInYear(day.getFullYear(), dow, doy);
     } else {
-        resYear = mom.getFullYear();
-        resWeek = week;
+        return week;
     }
-    return resWeek;
 }
 
 function eventsDateMatch(day: Date): DatepickerEvent[] {
@@ -193,7 +189,7 @@ function setRangeHoverEndDate(day): void {
     if (isTrueish(props.pickerProps.range)) emits("hover-enddate", day);
 }
 
-// --- Computed Component Classes ---
+// #region --- Computed Component Classes ---
 
 function dateMatch(
     dateOne: Date,
@@ -403,6 +399,8 @@ const cellEventsClass = defineClasses(
     // passing the picker props will add reactivity to property changes
     { props: props.pickerProps },
 );
+
+// #endregion --- Computed Component Classes ---
 </script>
 
 <template>
@@ -452,6 +450,14 @@ const cellEventsClass = defineClasses(
 
             <div v-else :class="cellClasses(weekDay)">
                 <span>{{ weekDay.getDate() }}</span>
+                <div
+                    v-if="eventsDateMatch(weekDay).length"
+                    :class="tableEventsClasses">
+                    <div
+                        v-for="(event, index) in eventsDateMatch(weekDay)"
+                        :key="index"
+                        :class="eventClasses(event)" />
+                </div>
             </div>
         </template>
     </div>

--- a/packages/oruga/src/components/datepicker/tests/__snapshots__/datepicker.unit.test.ts.snap
+++ b/packages/oruga/src/components/datepicker/tests/__snapshots__/datepicker.unit.test.ts.snap
@@ -173,12 +173,24 @@ exports[`ODatepicker > render correctly 1`] = `
             <div class="o-datepicker__table__body">
               <div class="o-datepicker__table__row">
                 <!--v-if-->
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>26</span></div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>27</span></div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>28</span></div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>29</span></div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>30</span></div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>31</span></div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>26</span>
+                  <!--v-if-->
+                </div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>27</span>
+                  <!--v-if-->
+                </div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>28</span>
+                  <!--v-if-->
+                </div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>29</span>
+                  <!--v-if-->
+                </div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>30</span>
+                  <!--v-if-->
+                </div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>31</span>
+                  <!--v-if-->
+                </div>
                 <div class="o-datepicker__table__cell o-datepicker__table__cell--selected o-datepicker__table__cell--today o-datepicker__table__cell--selectable" role="button"><span>1</span>
                   <!--v-if-->
                 </div>
@@ -287,11 +299,21 @@ exports[`ODatepicker > render correctly 1`] = `
                 <div class="o-datepicker__table__cell o-datepicker__table__cell--selectable" role="button" tabindex="0"><span>31</span>
                   <!--v-if-->
                 </div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>1</span></div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>2</span></div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>3</span></div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>4</span></div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>5</span></div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>1</span>
+                  <!--v-if-->
+                </div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>2</span>
+                  <!--v-if-->
+                </div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>3</span>
+                  <!--v-if-->
+                </div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>4</span>
+                  <!--v-if-->
+                </div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>5</span>
+                  <!--v-if-->
+                </div>
               </div>
             </div>
           </section>

--- a/packages/oruga/src/components/datetimepicker/tests/__snapshots__/datetimepicker.unit.test.ts.snap
+++ b/packages/oruga/src/components/datetimepicker/tests/__snapshots__/datetimepicker.unit.test.ts.snap
@@ -173,12 +173,24 @@ exports[`ODatetimepicker tests > render correctly 1`] = `
             <div class="o-datepicker__table__body">
               <div class="o-datepicker__table__row">
                 <!--v-if-->
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>26</span></div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>27</span></div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>28</span></div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>29</span></div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>30</span></div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--today o-datepicker__table__cell--unselectable"><span>31</span></div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>26</span>
+                  <!--v-if-->
+                </div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>27</span>
+                  <!--v-if-->
+                </div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>28</span>
+                  <!--v-if-->
+                </div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>29</span>
+                  <!--v-if-->
+                </div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>30</span>
+                  <!--v-if-->
+                </div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--today o-datepicker__table__cell--unselectable"><span>31</span>
+                  <!--v-if-->
+                </div>
                 <div class="o-datepicker__table__cell o-datepicker__table__cell--selected o-datepicker__table__cell--selectable" role="button"><span>1</span>
                   <!--v-if-->
                 </div>
@@ -287,11 +299,21 @@ exports[`ODatetimepicker tests > render correctly 1`] = `
                 <div class="o-datepicker__table__cell o-datepicker__table__cell--selectable" role="button" tabindex="0"><span>31</span>
                   <!--v-if-->
                 </div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>1</span></div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>2</span></div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>3</span></div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>4</span></div>
-                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>5</span></div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>1</span>
+                  <!--v-if-->
+                </div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>2</span>
+                  <!--v-if-->
+                </div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>3</span>
+                  <!--v-if-->
+                </div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>4</span>
+                  <!--v-if-->
+                </div>
+                <div class="o-datepicker__table__cell o-datepicker__table__cell--unselectable"><span>5</span>
+                  <!--v-if-->
+                </div>
               </div>
             </div>
           </section>


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #1614 

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- show events on the shown previous and next days in the month view
