### PR TITLE
fix(Input): add ResizeObserver to calc input size when type `textarea` and `autosize`

### DIFF
--- a/packages/oruga/src/components/autocomplete/examples/base.vue
+++ b/packages/oruga/src/components/autocomplete/examples/base.vue
@@ -31,8 +31,7 @@ const selected = ref<string>();
                 placeholder="e.g. jQuery"
                 icon="search"
                 clearable
-                open-on-focus>
-            </o-autocomplete>
+                open-on-focus />
 
             <p><b>Selected:</b> {{ selected }}</p>
         </o-field>

--- a/packages/oruga/src/components/input/Input.vue
+++ b/packages/oruga/src/components/input/Input.vue
@@ -163,10 +163,7 @@ onMounted(() => handleChange(vmodel.value));
 
 if (props.autosize && props.type !== "textarea") {
     const resizeObserver = window.ResizeObserver
-        ? new window.ResizeObserver(() => {
-              console.log("observe");
-              resize();
-          })
+        ? new window.ResizeObserver(resize)
         : undefined;
 
     onMounted(() => {

--- a/packages/oruga/src/components/input/Input.vue
+++ b/packages/oruga/src/components/input/Input.vue
@@ -14,6 +14,7 @@ import {
 import OIcon from "../icon/Icon.vue";
 
 import { getDefault } from "@/utils/config";
+import { isClient } from "@/utils/ssr";
 import { isDefined, isTrueish } from "@/utils/helpers";
 import {
     defineClasses,
@@ -112,6 +113,7 @@ const emits = defineEmits<{
 
 // --- Validation Feature ---
 
+const rootRef = useTemplateRef("rootElement");
 const inputRef = useTemplateRef<HTMLInputElement>("inputElement");
 
 // use form input functionalities
@@ -158,6 +160,22 @@ watch(
 );
 
 onMounted(() => handleChange(vmodel.value));
+
+if (props.autosize && props.type !== "textarea") {
+    const resizeObserver = window.ResizeObserver
+        ? new window.ResizeObserver(() => {
+              console.log("observe");
+              resize();
+          })
+        : undefined;
+
+    onMounted(() => {
+        // start resize observing
+        if (isClient && resizeObserver && rootRef.value) {
+            resizeObserver.observe(rootRef.value);
+        }
+    });
+}
 
 /**
  * Called when v-model changes:
@@ -366,7 +384,7 @@ defineExpose({ checkHtml5Validity, focus: setFocus, value: vmodel });
 </script>
 
 <template>
-    <div data-oruga="input" :class="rootClasses">
+    <div ref="rootElement" data-oruga="input" :class="rootClasses">
         <o-icon
             v-if="icon"
             :class="iconLeftClasses"

--- a/packages/oruga/src/components/input/Input.vue
+++ b/packages/oruga/src/components/input/Input.vue
@@ -161,7 +161,7 @@ watch(
 
 onMounted(() => handleChange(vmodel.value));
 
-if (props.autosize && props.type !== "textarea") {
+if (props.autosize && props.type === "textarea") {
     const resizeObserver = window.ResizeObserver
         ? new window.ResizeObserver(resize)
         : undefined;

--- a/packages/oruga/src/components/input/examples/base.vue
+++ b/packages/oruga/src/components/input/examples/base.vue
@@ -30,6 +30,7 @@
             <o-input
                 :maxlength="200"
                 type="textarea"
+                autosize
                 placeholder="Enter some text..." />
         </o-field>
 

--- a/packages/oruga/src/components/input/tests/input.browser.test.ts
+++ b/packages/oruga/src/components/input/tests/input.browser.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "vitest";
+import { userEvent } from "vitest/browser";
+import { render } from "vitest-browser-vue";
+
+import { defineComponent, h, nextTick } from "vue";
+
+import OInput from "../Input.vue";
+import OField from "../../field/Field.vue";
+
+const BrowserInput = defineComponent(
+    () => () =>
+        h(
+            OField,
+            { label: "My Input" },
+            {
+                default: () =>
+                    h(OInput, {
+                        placeholder: "e.g. jQuery",
+                        icon: "search",
+                        clearable: true,
+                    }),
+            },
+        ),
+);
+
+describe("<Input>", () => {
+    test("works", async () => {
+        const screen = render(BrowserInput);
+        const input = screen.container.querySelector("input");
+        expect(input).toBeTruthy();
+        await userEvent.click(input!);
+        await expect.element(input).toHaveFocus();
+        await userEvent.keyboard("j");
+        screen.unmount();
+    });
+
+    test("does resize correctly when textarea is hidden at mount time", async () => {
+        const HiddenTextarea = defineComponent(
+            () => () =>
+                h(
+                    "div",
+                    {
+                        id: "hidden-container",
+                        style: "display: none;",
+                    },
+                    [
+                        h(OInput, {
+                            type: "textarea",
+                            autosize: true,
+                            modelValue: "test content",
+                        }),
+                    ],
+                ),
+        );
+
+        const screen = render(HiddenTextarea);
+        await nextTick();
+
+        const textarea = screen.container.querySelector("textarea");
+        expect(textarea).toBeTruthy();
+
+        // When mounted in a hidden container, scrollHeight is 0 and the textarea height stays 0px
+        expect(textarea!.scrollHeight).toBe(0);
+        expect(textarea!.style.height).toBe("auto");
+
+        const hiddenContainer =
+            screen.container.querySelector("#hidden-container");
+        expect(hiddenContainer).toBeTruthy();
+        hiddenContainer!.setAttribute("style", "display: block;");
+
+        await new Promise((r) => setTimeout(r, 200)); // await async resize observer is run
+
+        expect(textarea!.style.height).not.toBe("0px");
+        expect(textarea!.scrollHeight).toBeGreaterThan(0);
+        expect(parseInt(textarea!.style.height)).toBeGreaterThan(0);
+
+        screen.unmount();
+    });
+});


### PR DESCRIPTION
Fixes #1628

## Proposed Changes

- add a ResizeObserver on the Input component to call resize an change when type is `textarea` and `autosize` is `true`
