### PR TITLE
chore: add eslint compat for browser compatibility check

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import eslint from "@eslint/js";
 import { globalIgnores } from "eslint/config";
 import { includeIgnoreFile } from "@eslint/compat";
+import compat from "eslint-plugin-compat";
 import vuePlugin from "eslint-plugin-vue";
 import {
   configureVueProject,
@@ -35,6 +36,9 @@ export default defineConfigWithVueTs([
 
   // include .gitignore ignore patterns
   includeIgnoreFile(gitignorePath),
+
+  // add browser compatibility configs
+  compat.configs["flat/recommended"],
 
   // add js configs
   eslint.configs.recommended,

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "conventional-changelog": "^7.2.0",
         "conventional-changelog-conventionalcommits": "9.3.1",
         "eslint": "^10.2.0",
+        "eslint-plugin-compat": "^7.0.1",
         "eslint-plugin-vue": "^10.8.0",
         "eslint-plugin-vuejs-accessibility": "^2.5.0",
         "npm-check-updates": "^22.2.3",
@@ -1342,6 +1343,13 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/@mdn/browser-compat-data": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-6.1.5.tgz",
+      "integrity": "sha1-ptcmZn24AErEPeBrcASR162fsr8=",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.58.2",
@@ -4256,6 +4264,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-metadata-inferer": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.8.1.tgz",
+      "integrity": "sha1-hQgb8wMIrNTDX7hpRli0xfbz7mA=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mdn/browser-compat-data": "^5.6.19"
+      }
+    },
+    "node_modules/ast-metadata-inferer/node_modules/@mdn/browser-compat-data": {
+      "version": "5.7.6",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.7.6.tgz",
+      "integrity": "sha1-GQ1GY/oDaI2Fsx9BVkHHY8s3byk=",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -4312,6 +4337,19 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.36",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.36.tgz",
+      "integrity": "sha1-/zx8hwlccAdbGseHFg/U/Jh1CnQ=",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bidi-js": {
@@ -4399,6 +4437,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha1-9QtlNi70iXTKn1CzaAVm14a4EdI=",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/bulma": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bulma/-/bulma-1.0.4.tgz",
@@ -4445,6 +4517,27 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha1-XJCROMJ/GmEhnT4JIHHBzH0y3FU=",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -5026,6 +5119,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.372",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
+      "integrity": "sha1-rorGmUKjeyMXc7j7AXWfc3M1meM=",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
@@ -5219,6 +5319,41 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-compat": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-7.0.2.tgz",
+      "integrity": "sha1-C7aq9oEnys10o+n0LCvhYhM8s+U=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mdn/browser-compat-data": "^6.1.1",
+        "ast-metadata-inferer": "^0.8.1",
+        "browserslist": "^4.25.2",
+        "find-up": "^5.0.0",
+        "globals": "^15.7.0",
+        "lodash.memoize": "^4.1.2",
+        "semver": "^7.6.2"
+      },
+      "engines": {
+        "node": ">=22.x"
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-compat/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha1-fEdhKZ1BwysHVxWkzh7eeJf/cqg=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -7634,6 +7769,16 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha1-UhuyeG2o6xQLdIhBwLOzp1M0/8Q=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nopt": {
       "version": "7.2.1",
@@ -10063,6 +10208,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha1-ZNdttYcTE2rL60xJEUNmzGzC6A0=",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "conventional-changelog": "^7.2.0",
     "conventional-changelog-conventionalcommits": "9.3.1",
     "eslint": "^10.2.0",
+    "eslint-plugin-compat": "^7.0.1",
     "eslint-plugin-vue": "^10.8.0",
     "eslint-plugin-vuejs-accessibility": "^2.5.0",
     "npm-check-updates": "^22.2.3",
@@ -64,5 +65,9 @@
     "typescript": "^6.0.2",
     "vue-component-meta": "^3.3.3",
     "vue-tsc": "^3.3.3"
-  }
+  },
+  "browserslist": [
+    "defaults",
+    "not op_mini all"
+  ]
 }

--- a/packages/oruga/src/components/carousel/Carousel.vue
+++ b/packages/oruga/src/components/carousel/Carousel.vue
@@ -181,10 +181,11 @@ const indicatorItems = computed(() =>
     ),
 );
 
-const resizeObserver =
-    isClient && window.ResizeObserver
-        ? new window.ResizeObserver(onRefresh)
-        : undefined;
+let resizeObserver: ResizeObserver | undefined;
+
+if (isClient && window.ResizeObserver) {
+    resizeObserver = new window.ResizeObserver(onRefresh);
+}
 
 const windowWidth = ref(0);
 


### PR DESCRIPTION
## Proposed Changes

- add [`eslint-plugin-compat`](https://github.com/amilajack/eslint-plugin-compat) lint rules to check browser compatability
- add browserslist [`defaults`](https://github.com/browserslist/browserslist#full-list) without `op_mini` config to package.json
