### PR TITLE
refactor: simplify `useEventListener` composable

### DIFF
--- a/packages/oruga/src/components/modal/Modal.vue
+++ b/packages/oruga/src/components/modal/Modal.vue
@@ -128,7 +128,10 @@ const showX = computed(() => props.closeable);
 
 if (isClient) {
     // register onKeyup event listener when is active
-    useEventListener(rootRef, "keyup", onKeyup, { trigger: isActive });
+    useEventListener(rootRef, "keyup", onKeyup, {
+        trigger: isActive,
+        passive: true,
+    });
 
     if (!props.overlay)
         // register outside click event listener when is active

--- a/packages/oruga/src/components/sidebar/Sidebar.vue
+++ b/packages/oruga/src/components/sidebar/Sidebar.vue
@@ -128,7 +128,10 @@ onMounted(() => {
 
 if (isClient) {
     // register onKeyup event listener when is active
-    useEventListener(rootRef, "keyup", onKeyup, { trigger: isActive });
+    useEventListener(rootRef, "keyup", onKeyup, {
+        trigger: isActive,
+        passive: true,
+    });
 
     if (!props.overlay && !props.inline)
         // register outside click event listener when is active

--- a/packages/oruga/src/components/slider/SliderThumb.vue
+++ b/packages/oruga/src/components/slider/SliderThumb.vue
@@ -220,7 +220,7 @@ defineExpose({ setPosition });
                 :aria-valuemax="max"
                 :aria-disabled="disabled"
                 aria-orientation="horizontal"
-                @pointerdown.passive="onButtonDown"
+                @pointerdown="onButtonDown"
                 @focus="onFocus"
                 @blur="onBlur"
                 @keydown.left.prevent="onLeftKeyDown"

--- a/packages/oruga/src/composables/tests/useEventListener.test.ts
+++ b/packages/oruga/src/composables/tests/useEventListener.test.ts
@@ -27,7 +27,6 @@ describe("useEventListener test", () => {
     afterEach(() => {
         vi.restoreAllMocks();
     });
-
     test("should be defined", () => {
         expect(useEventListener).toBeDefined();
     });
@@ -39,6 +38,7 @@ describe("useEventListener test", () => {
             useEventListener(target, event, listener, {
                 immediate: true,
             });
+
             expect(addSpy).toHaveBeenCalledTimes(1);
         });
 
@@ -93,6 +93,7 @@ describe("useEventListener test", () => {
 
         test(`should listen event`, async () => {
             useEventListener(target, event, listener, { immediate: true });
+
             target.value?.dispatchEvent(new PointerEvent(event));
 
             await nextTick();
@@ -101,12 +102,11 @@ describe("useEventListener test", () => {
         });
 
         test(`should manually stop listening event`, async () => {
-            scope.run(() => {
-                const stop = useEventListener(target, event, listener, {
-                    immediate: true,
-                });
-                stop();
+            const stop = useEventListener(target, event, listener, {
+                immediate: true,
             });
+            stop();
+
             target.value?.dispatchEvent(new PointerEvent(event));
 
             await nextTick();

--- a/packages/oruga/src/composables/tests/useEventListener.test.ts
+++ b/packages/oruga/src/composables/tests/useEventListener.test.ts
@@ -7,20 +7,17 @@ import {
     vi,
     type MockInstance,
 } from "vitest";
-import { effectScope, nextTick, ref } from "vue";
+import { EffectScope, effectScope, nextTick, ref } from "vue";
 
-import { useEventListener, type EventListenerOptions } from "../";
+import { useEventListener } from "../";
 
 describe("useEventListener test", () => {
-    const options: EventListenerOptions = { immediate: true };
-    let stop: () => void;
     let target: HTMLDivElement;
     let removeSpy: MockInstance;
     let addSpy: MockInstance;
     let listener: () => void;
 
     beforeEach(() => {
-        vi.useFakeTimers();
         target = document.createElement("div");
         removeSpy = vi.spyOn(target, "removeEventListener");
         addSpy = vi.spyOn(target, "addEventListener");
@@ -39,49 +36,52 @@ describe("useEventListener test", () => {
         const event = "click";
 
         test("should add listener", () => {
-            stop = useEventListener(target, event, listener, {
+            useEventListener(target, event, listener, {
                 immediate: true,
             });
-            vi.runAllTimers();
-            expect(addSpy).toBeCalledTimes(1);
+            expect(addSpy).toHaveBeenCalledTimes(1);
         });
 
         test("should trigger listener", () => {
-            stop = useEventListener(target, event, listener, {
+            useEventListener(target, event, listener, {
                 immediate: true,
             });
-            vi.runAllTimers();
-            expect(listener).not.toBeCalled();
+
+            expect(listener).not.toHaveBeenCalled();
             target.dispatchEvent(new PointerEvent(event));
-            expect(listener).toBeCalledTimes(1);
+            expect(listener).toHaveBeenCalledTimes(1);
         });
 
         test("should remove listener", () => {
-            stop = useEventListener(target, event, listener, {
+            const stop = useEventListener(target, event, listener, {
                 immediate: true,
             });
-            vi.runAllTimers();
-            expect(removeSpy).not.toBeCalled();
 
+            expect(removeSpy).not.toHaveBeenCalled();
             stop();
 
-            expect(removeSpy).toBeCalledTimes(1);
-            expect(removeSpy).toBeCalledWith(event, listener, options);
+            expect(removeSpy).toHaveBeenCalledTimes(1);
+            expect(removeSpy).toHaveBeenCalledWith(event, listener, {
+                immediate: true,
+            });
         });
     });
 
     describe("reactive target", () => {
+        let scope: EffectScope;
         const event = "click";
         const target = ref<HTMLDivElement | null>(
             document.createElement("div"),
         );
 
         beforeEach(() => {
+            scope = effectScope();
             target.value = document.createElement("div");
         });
 
         test("should not listen when target is invalid", async () => {
             useEventListener(target, event, listener);
+
             const el = target.value;
             target.value = null;
             await nextTick();
@@ -93,7 +93,6 @@ describe("useEventListener test", () => {
 
         test(`should listen event`, async () => {
             useEventListener(target, event, listener, { immediate: true });
-            vi.runAllTimers();
             target.value?.dispatchEvent(new PointerEvent(event));
 
             await nextTick();
@@ -102,12 +101,12 @@ describe("useEventListener test", () => {
         });
 
         test(`should manually stop listening event`, async () => {
-            const stop = useEventListener(target, event, listener, {
-                immediate: true,
+            scope.run(() => {
+                const stop = useEventListener(target, event, listener, {
+                    immediate: true,
+                });
+                stop();
             });
-
-            stop();
-
             target.value?.dispatchEvent(new PointerEvent(event));
 
             await nextTick();
@@ -116,7 +115,6 @@ describe("useEventListener test", () => {
         });
 
         test(`should auto stop listening event`, async () => {
-            const scope = effectScope();
             scope.run(() => {
                 useEventListener(target, event, listener, {
                     immediate: true,
@@ -138,12 +136,10 @@ describe("useEventListener test", () => {
 
         useEventListener(target, "click", listener, { trigger });
 
-        vi.runAllTimers();
         expect(addSpy).toHaveBeenCalledTimes(0);
 
         trigger.value = true;
         await nextTick();
-        vi.runAllTimers();
 
         expect(addSpy).toHaveBeenCalledTimes(1);
         expect(addSpy).toHaveBeenLastCalledWith("click", listener, { trigger });
@@ -151,7 +147,6 @@ describe("useEventListener test", () => {
 
         trigger.value = false;
         await nextTick();
-        vi.runAllTimers();
 
         await nextTick();
         expect(addSpy).toHaveBeenCalledTimes(1);

--- a/packages/oruga/src/composables/useEventListener.ts
+++ b/packages/oruga/src/composables/useEventListener.ts
@@ -6,6 +6,7 @@ import {
     type MaybeRefOrGetter,
     type Component,
     type WatchSource,
+    isRef,
     toValue,
 } from "vue";
 import { isObject } from "@/utils/helpers";
@@ -20,9 +21,9 @@ export type EventTarget =
     | undefined;
 
 export type EventListenerOptions = AddEventListenerOptions & {
-    /** Register event listener immediate or on mounted hook. */
+    /** Register event listener immediate. Otherwise it will be registered on mounted hook. */
     immediate?: boolean;
-    /** Trigger when the listener get registered and removed */
+    /** Define a custom trigger when the listener get registered and removed. */
     trigger?: WatchSource<boolean>;
 };
 
@@ -39,7 +40,7 @@ export type EventListenerOptions = AddEventListenerOptions & {
 export function useEventListener(
     element: MaybeRefOrGetter<EventTarget>,
     event: string,
-    handler: (evt?: any) => void,
+    handler: (evt?: Event) => void,
     options?: EventListenerOptions,
 ): () => void {
     let cleanup: () => void;
@@ -50,44 +51,52 @@ export function useEventListener(
 
         // create a clone of options, to avoid it being changed reactively on removal
         const optionsClone = isObject(options) ? { ...options } : options;
-        // register listener with timeout to prevent animation collision
-        setTimeout(() => {
-            target.addEventListener(event, handler, optionsClone);
-            cleanup = (): void => {
-                target.removeEventListener(event, handler, optionsClone);
-            };
-        });
+        target.addEventListener(event, handler, optionsClone);
+        cleanup = (): void => {
+            target.removeEventListener(event, handler, optionsClone);
+        };
     };
 
-    let stopWatch: () => void;
+    let stopWatchTrigger: () => void;
+    let stopWatchElement: () => void;
 
-    if (typeof options?.trigger !== "undefined") {
-        stopWatch = watch(
-            options.trigger,
-            (value) => {
-                // toggle listener
-                if (value) register();
-                else if (typeof cleanup === "function") cleanup();
-            },
-            { flush: "post" },
-        );
+    function toggleListener(value: unknown): void {
+        if (value) register();
+        else if (typeof cleanup === "function") cleanup();
     }
 
-    if (options?.immediate) register();
-    else if (getCurrentScope()) {
-        // register listener on mount
-        onMounted(() => {
-            if (
-                typeof options?.trigger === "undefined" ||
-                toValue(options.trigger)
-            )
-                register();
+    if (typeof options?.trigger !== "undefined") {
+        /// when we have a trigger we watch the trigger
+        stopWatchTrigger = watch(options.trigger, toggleListener, {
+            flush: "post",
         });
+        /// and we check if the trigger is initial true
+        /// then we register on component mount
+        if (toValue(options.trigger) && getCurrentScope()) {
+            onMounted(() => register());
+        }
+    } else {
+        /// if we don't have a trigger, we check if the element is a ref (templateRef)
+        /// then we watch the ref get initialised
+        if (isRef(element)) {
+            stopWatchElement = watch(element, toggleListener, {
+                flush: "post",
+            });
+        }
+        /// otherwise we register on component mount
+        else if (getCurrentScope()) {
+            onMounted(() => register());
+        }
+    }
+
+    if (options?.immediate) {
+        register();
     }
 
     const stop = (): void => {
         // remove listener before unmounting
-        if (typeof stopWatch === "function") stopWatch();
+        if (typeof stopWatchTrigger === "function") stopWatchTrigger();
+        if (typeof stopWatchElement === "function") stopWatchElement();
         if (typeof cleanup === "function") cleanup();
     };
 

--- a/packages/oruga/src/composables/useEventListener.ts
+++ b/packages/oruga/src/composables/useEventListener.ts
@@ -23,7 +23,7 @@ export type EventTarget =
 export type EventListenerOptions = AddEventListenerOptions & {
     /** Register event listener immediate. Otherwise it will be registered on mounted hook. */
     immediate?: boolean;
-    /** Define a custom trigger when the listener get registered and removed. */
+    /** Use a custom trigger to define when the listener get registered and removed. */
     trigger?: WatchSource<boolean>;
 };
 
@@ -40,7 +40,7 @@ export type EventListenerOptions = AddEventListenerOptions & {
 export function useEventListener(
     element: MaybeRefOrGetter<EventTarget>,
     event: string,
-    handler: (evt?: Event) => void,
+    handler: (evt: any) => void,
     options?: EventListenerOptions,
 ): () => void {
     let cleanup: () => void;

--- a/packages/oruga/src/composables/useEventListener.ts
+++ b/packages/oruga/src/composables/useEventListener.ts
@@ -57,8 +57,7 @@ export function useEventListener(
         };
     };
 
-    let stopWatchTrigger: () => void;
-    let stopWatchElement: () => void;
+    let stopWatch: () => void;
 
     function toggleListener(value: unknown): void {
         if (value) register();
@@ -67,7 +66,7 @@ export function useEventListener(
 
     if (typeof options?.trigger !== "undefined") {
         /// when we have a trigger we watch the trigger
-        stopWatchTrigger = watch(options.trigger, toggleListener, {
+        stopWatch = watch(options.trigger, toggleListener, {
             flush: "post",
         });
         /// and we check if the trigger is initial true
@@ -79,7 +78,7 @@ export function useEventListener(
         /// if we don't have a trigger, we check if the element is a ref (templateRef)
         /// then we watch the ref get initialised
         if (isRef(element)) {
-            stopWatchElement = watch(element, toggleListener, {
+            stopWatch = watch(element, toggleListener, {
                 flush: "post",
             });
         }
@@ -95,8 +94,7 @@ export function useEventListener(
 
     const stop = (): void => {
         // remove listener before unmounting
-        if (typeof stopWatchTrigger === "function") stopWatchTrigger();
-        if (typeof stopWatchElement === "function") stopWatchElement();
+        if (typeof stopWatch === "function") stopWatch();
         if (typeof cleanup === "function") cleanup();
     };
 

--- a/packages/oruga/src/composables/useMatchMedia.ts
+++ b/packages/oruga/src/composables/useMatchMedia.ts
@@ -44,7 +44,9 @@ export function useMatchMedia(mobileBreakpoint?: string): {
 
     if (mediaQuery.value) {
         isMobile.value = mediaQuery.value.matches;
-        useEventListener(mediaQuery.value, "change", onMatchMedia);
+        useEventListener(mediaQuery.value, "change", onMatchMedia, {
+            passive: true,
+        });
     } else {
         isMobile.value = false;
     }


### PR DESCRIPTION

## Proposed Changes

- simplify `useEventListener` composable
- update `useEventListener` to dynamicaly add listeners when target get available and not when component get mounted
  - when element is a ref, we watch the ref instead of use onMounted to register the listener