### PR TITLE
feat(table): expose `filteredRows` and `pageRows` readonly refs

### DIFF
--- a/packages/oruga/src/components/table/Table.vue
+++ b/packages/oruga/src/components/table/Table.vue
@@ -9,9 +9,9 @@ import {
     useTemplateRef,
     toRaw,
     triggerRef,
+    shallowReadonly,
     type MaybeRefOrGetter,
     type VNode,
-    shallowReadonly,
 } from "vue";
 
 import OCheckbox from "@/components/checkbox/Checkbox.vue";

--- a/packages/oruga/src/components/table/Table.vue
+++ b/packages/oruga/src/components/table/Table.vue
@@ -11,6 +11,7 @@ import {
     triggerRef,
     type MaybeRefOrGetter,
     type VNode,
+    shallowReadonly,
 } from "vue";
 
 import OCheckbox from "@/components/checkbox/Checkbox.vue";
@@ -1217,8 +1218,10 @@ function rowClasses(row: TableRow<T>): ClassBinding[] {
 
 /** expose functionalities for programmatic usage */
 defineExpose({
-    columns: tableColumns,
-    rows: tableRows,
+    columns: shallowReadonly(tableColumns),
+    rows: shallowReadonly(tableRows),
+    filteredRows: shallowReadonly(filteredRows),
+    pageRows: shallowReadonly(availableRows),
     filters,
     sort: sortByField,
 });

--- a/packages/oruga/src/components/table/examples/filterable.vue
+++ b/packages/oruga/src/components/table/examples/filterable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, useTemplateRef, watch } from "vue";
+import { ref } from "vue";
 import type { TableColumn } from "@oruga-ui/oruga-next";
 
 const data = [
@@ -212,13 +212,6 @@ const columns: TableColumn<(typeof data)[number]>[] = [
 ];
 
 const isPaginated = ref(true);
-
-const table = useTemplateRef("table");
-
-watch(
-    () => table.value?.filteredRows,
-    () => console.log(table.value?.filteredRows),
-);
 </script>
 
 <template>
@@ -236,7 +229,7 @@ watch(
 
         <p>You can also customize the search input using a scoped slot.</p>
 
-        <o-table ref="table" :data="data" :paginated="isPaginated" per-page="5">
+        <o-table :data="data" :paginated="isPaginated" per-page="5">
             <o-table-column
                 v-for="(column, idx) in columns"
                 :key="idx"

--- a/packages/oruga/src/components/table/examples/filterable.vue
+++ b/packages/oruga/src/components/table/examples/filterable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, useTemplateRef, watch } from "vue";
 import type { TableColumn } from "@oruga-ui/oruga-next";
 
 const data = [
@@ -212,6 +212,13 @@ const columns: TableColumn<(typeof data)[number]>[] = [
 ];
 
 const isPaginated = ref(true);
+
+const table = useTemplateRef("table");
+
+watch(
+    () => table.value?.filteredRows,
+    () => console.log(table.value?.filteredRows),
+);
 </script>
 
 <template>
@@ -229,7 +236,7 @@ const isPaginated = ref(true);
 
         <p>You can also customize the search input using a scoped slot.</p>
 
-        <o-table :data="data" :paginated="isPaginated" per-page="5">
+        <o-table ref="table" :data="data" :paginated="isPaginated" per-page="5">
             <o-table-column
                 v-for="(column, idx) in columns"
                 :key="idx"


### PR DESCRIPTION
## Proposed Changes

- expose `filteredRows` and `pageRows` readonly refs on the OTable component