### PR TITLE
feat(button): add icon override template slots

### DIFF
--- a/packages/docs/pages/components/Button.md
+++ b/packages/docs/pages/components/Button.md
@@ -57,9 +57,11 @@ The component implements the W3C ARIA APG [Button Pattern](https://www.w3.org/WA
 
 ### Slots
 
-| Name    | Description                               | Bindings |
-| ------- | ----------------------------------------- | -------- |
-| default | Override the label, default is label prop |          |
+| Name      | Description                               | Bindings                                                                     |
+| --------- | ----------------------------------------- | ---------------------------------------------------------------------------- |
+| iconLeft  | Override the left icon.                   | **icon** `string` - The icon name.<br/>**icon** `string` - The icon size. \* |
+| default   | Override the label, default is label prop |                                                                              |
+| iconRight | Override the left icon.                   | **icon** `string` - The icon name.<br/>**icon** `string` - The icon size. \* |
 
 </section>
 

--- a/packages/docs/pages/components/Button.md
+++ b/packages/docs/pages/components/Button.md
@@ -57,11 +57,11 @@ The component implements the W3C ARIA APG [Button Pattern](https://www.w3.org/WA
 
 ### Slots
 
-| Name      | Description                               | Bindings                                                                     |
-| --------- | ----------------------------------------- | ---------------------------------------------------------------------------- |
-| iconLeft  | Override the left icon.                   | **icon** `string` - The icon name.<br/>**icon** `string` - The icon size. \* |
-| default   | Override the label, default is label prop |                                                                              |
-| iconRight | Override the left icon.                   | **icon** `string` - The icon name.<br/>**icon** `string` - The icon size. \* |
+| Name    | Description                               | Bindings |
+| ------- | ----------------------------------------- | -------- |
+| left    | Override the left icon.                   |          |
+| default | Override the label, default is label prop |          |
+| right   | Override the left icon.                   |          |
 
 </section>
 

--- a/packages/docs/pages/components/Button.md
+++ b/packages/docs/pages/components/Button.md
@@ -61,7 +61,7 @@ The component implements the W3C ARIA APG [Button Pattern](https://www.w3.org/WA
 | ------- | ----------------------------------------- | -------- |
 | left    | Override the left icon.                   |          |
 | default | Override the label, default is label prop |          |
-| right   | Override the left icon.                   |          |
+| right   | Override the right icon.                  |          |
 
 </section>
 

--- a/packages/oruga/src/components/button/Button.vue
+++ b/packages/oruga/src/components/button/Button.vue
@@ -50,7 +50,7 @@ defineSlots<{
     default?(): void;
     /** Override the left icon. */
     left?(): void;
-    /** Override the left icon. */
+    /** Override the right icon. */
     right?(): void;
 }>();
 

--- a/packages/oruga/src/components/button/Button.vue
+++ b/packages/oruga/src/components/button/Button.vue
@@ -48,6 +48,18 @@ defineEmits<{
 defineSlots<{
     /** Override the label, default is label prop */
     default?(): void;
+    /**
+     * Override the left icon.
+     * @param icon {string} - The icon name.
+     * @param icon {string} - The icon size.     *
+     */
+    iconLeft?(props: { icon: string; size: string }): void;
+    /**
+     * Override the left icon.
+     * @param icon {string} - The icon name.
+     * @param icon {string} - The icon size.     *
+     */
+    iconRight?(props: { icon: string; size: string }): void;
 }>();
 
 const computedNativeType = computed(() =>
@@ -128,23 +140,29 @@ const iconRightClasses = defineClasses([
         @keydown.enter.prevent="$emit('click', $event)"
         @keydown.space.prevent="$emit('click', $event)">
         <span :class="wrapperClasses">
-            <o-icon
-                v-if="iconLeft"
-                :pack="iconPack"
-                :icon="iconLeft"
-                :size="size"
-                :class="[...iconClasses, ...iconLeftClasses]" />
+            <slot v-if="iconLeft" name="iconLeft" :icon="iconLeft" :size="size">
+                <o-icon
+                    :pack="iconPack"
+                    :icon="iconLeft"
+                    :size="size"
+                    :class="[...iconClasses, ...iconLeftClasses]" />
+            </slot>
 
             <span v-if="label || $slots.default" :class="labelClasses">
                 <slot>{{ label }}</slot>
             </span>
 
-            <o-icon
+            <slot
                 v-if="iconRight"
-                :pack="iconPack"
+                name="iconRight"
                 :icon="iconRight"
-                :size="size"
-                :class="[...iconClasses, ...iconRightClasses]" />
+                :size="size">
+                <o-icon
+                    :pack="iconPack"
+                    :icon="iconRight"
+                    :size="size"
+                    :class="[...iconClasses, ...iconRightClasses]" />
+            </slot>
         </span>
     </component>
 </template>

--- a/packages/oruga/src/components/button/Button.vue
+++ b/packages/oruga/src/components/button/Button.vue
@@ -48,18 +48,10 @@ defineEmits<{
 defineSlots<{
     /** Override the label, default is label prop */
     default?(): void;
-    /**
-     * Override the left icon.
-     * @param icon {string} - The icon name.
-     * @param icon {string} - The icon size.     *
-     */
-    iconLeft?(props: { icon: string; size: string }): void;
-    /**
-     * Override the left icon.
-     * @param icon {string} - The icon name.
-     * @param icon {string} - The icon size.     *
-     */
-    iconRight?(props: { icon: string; size: string }): void;
+    /** Override the left icon. */
+    left?(): void;
+    /** Override the left icon. */
+    right?(): void;
 }>();
 
 const computedNativeType = computed(() =>
@@ -140,8 +132,9 @@ const iconRightClasses = defineClasses([
         @keydown.enter.prevent="$emit('click', $event)"
         @keydown.space.prevent="$emit('click', $event)">
         <span :class="wrapperClasses">
-            <slot v-if="iconLeft" name="iconLeft" :icon="iconLeft" :size="size">
+            <slot name="left">
                 <o-icon
+                    v-if="iconLeft"
                     :pack="iconPack"
                     :icon="iconLeft"
                     :size="size"
@@ -152,12 +145,9 @@ const iconRightClasses = defineClasses([
                 <slot>{{ label }}</slot>
             </span>
 
-            <slot
-                v-if="iconRight"
-                name="iconRight"
-                :icon="iconRight"
-                :size="size">
+            <slot name="right">
                 <o-icon
+                    v-if="iconRight"
                     :pack="iconPack"
                     :icon="iconRight"
                     :size="size"


### PR DESCRIPTION
## Proposed Changes

- Add optional `iconLeft` and `iconRight` slots to the OButton component, to customise the icons. 
