### PR TITLE
refactor: change prop `modalClass` to `contentModalClass`

### DIFF
--- a/packages/oruga/src/components/datepicker/Datepicker.vue
+++ b/packages/oruga/src/components/datepicker/Datepicker.vue
@@ -550,7 +550,6 @@ const rootClasses = defineClasses(
         computed(() => props.expanded),
     ],
     ["mobileClass", "o-datepicker--mobile", null, isMobile],
-    ["modalClass", "o-datepicker--modal", null, isModal],
     ["activeClass", "o-datepicker--active", null, isActive],
     [
         "teleportClass",
@@ -564,6 +563,7 @@ const triggerClasses = defineClasses(["triggerClass", "o-datepicker__trigger"]);
 const contentClasses = defineClasses(
     ["contentClass", "o-datepicker__content"],
     ["contentActiveClass", "o-datepicker__content--active", null, isActive],
+    ["contentModalClass", "o-datepicker__content--modal", null, isModal],
     ["contentBackdropClass", "o-datepicker__content--backdrop", null, isModal],
 );
 

--- a/packages/oruga/src/components/datepicker/examples/inspector.vue
+++ b/packages/oruga/src/components/datepicker/examples/inspector.vue
@@ -26,16 +26,6 @@ const inspectData: InspectData<
         description: "Class of the root element when on mobile.",
         info: "Switch to mobile view to see it in action!",
     },
-    modalClass: {
-        class: "modalClass",
-        description: "Class of the root element when shown as modal.",
-        properties: ["mobileModal", "desktopModal"],
-        action: (data): void => {
-            data.mobileModal = true;
-            data.desktopModal = true;
-            data.active = true;
-        },
-    },
     disabledClass: {
         class: "disabledClass",
         description: "Class of the root element when disabled.",
@@ -96,6 +86,16 @@ const inspectData: InspectData<
         description: "Class of the content element when active.",
         properties: ["active"],
         action: (data): void => {
+            data.active = true;
+        },
+    },
+    contentModalClass: {
+        class: "contentModalClass",
+        description: "Class of the content element when shown as modal.",
+        properties: ["mobileModal", "desktopModal"],
+        action: (data): void => {
+            data.mobileModal = true;
+            data.desktopModal = true;
             data.active = true;
         },
     },

--- a/packages/oruga/src/components/datepicker/props.ts
+++ b/packages/oruga/src/components/datepicker/props.ts
@@ -157,8 +157,6 @@ export type DatepickerClasses = Partial<{
     rootClass: ComponentClass;
     /** Class of the root element when on mobile */
     mobileClass: ComponentClass;
-    /** Class of the root element when shown as modal */
-    modalClass: ComponentClass;
     /** Class of the root element when teleported */
     teleportClass: ComponentClass;
     /** Class of the root element when disabled */
@@ -175,6 +173,8 @@ export type DatepickerClasses = Partial<{
     contentClass: ComponentClass;
     /** Class of the content element when active or inline */
     contentActiveClass: ComponentClass;
+    /** Class of the content element when shown as modal */
+    contentModalClass: ComponentClass;
     /** Class of the content element when should has a backdrop */
     contentBackdropClass: ComponentClass;
     /** Class of the header element inside the box */

--- a/packages/oruga/src/components/dropdown/Dropdown.vue
+++ b/packages/oruga/src/components/dropdown/Dropdown.vue
@@ -562,7 +562,6 @@ const rootClasses = defineClasses(
         computed(() => props.expanded),
     ],
     ["mobileClass", "o-dropdown--mobile", null, isMobile],
-    ["modalClass", "o-dropdown--modal", null, isModal],
     ["hoverableClass", "o-dropdown--hoverable", null, hoverable],
     ["activeClass", "o-dropdown--active", null, isActive],
     [
@@ -579,6 +578,7 @@ const contentClasses = defineClasses(
     ["menuClass", "o-dropdown__menu"],
     ["contentClass", "o-dropdown__content"],
     ["contentActiveClass", "o-dropdown__content--active", null, isActive],
+    ["contentModalClass", "o-dropdown__content--modal", null, isModal],
     ["contentBackdropClass", "o-dropdown__content--backdrop", null, isModal],
 );
 

--- a/packages/oruga/src/components/dropdown/examples/inspector.vue
+++ b/packages/oruga/src/components/dropdown/examples/inspector.vue
@@ -20,16 +20,6 @@ const inspectData: InspectData<
         description: "Class of the root element when on mobile.",
         info: "Switch to mobile view to see it in action!",
     },
-    modalClass: {
-        class: "modalClass",
-        description: "Class of the root element when shown as modal.",
-        properties: ["mobileModal", "desktopModal"],
-        action: (data): void => {
-            data.mobileModal = true;
-            data.desktopModal = true;
-            data.active = true;
-        },
-    },
     teleportClass: {
         class: "teleportClass",
         description: "Class of the root element when teleported.",
@@ -94,6 +84,16 @@ const inspectData: InspectData<
         description: "Class of the content element when active.",
         properties: ["active"],
         action: (data): void => {
+            data.active = true;
+        },
+    },
+    contentModalClass: {
+        class: "contentModalClass",
+        description: "Class of the content element when shown as modal.",
+        properties: ["mobileModal", "desktopModal"],
+        action: (data): void => {
+            data.mobileModal = true;
+            data.desktopModal = true;
             data.active = true;
         },
     },

--- a/packages/oruga/src/components/dropdown/props.ts
+++ b/packages/oruga/src/components/dropdown/props.ts
@@ -97,8 +97,6 @@ export type DropdownClasses = Partial<{
     rootClass: ComponentClass;
     /** Class of the root element when on mobile */
     mobileClass: ComponentClass;
-    /** Class of the root element when shown as modal */
-    modalClass: ComponentClass;
     /** Class of the root element when teleported */
     teleportClass: ComponentClass;
     /** Class of the root element when disabled */
@@ -117,6 +115,8 @@ export type DropdownClasses = Partial<{
     contentClass: ComponentClass;
     /** Class of the content element when active */
     contentActiveClass: ComponentClass;
+    /** Class of the content element when shown as modal */
+    contentModalClass: ComponentClass;
     /** Class of the content element when should has a backdrop */
     contentBackdropClass: ComponentClass;
     /** Class of the body when dropdown is open and scroll is clipped */

--- a/packages/oruga/src/components/popover/Popover.vue
+++ b/packages/oruga/src/components/popover/Popover.vue
@@ -171,7 +171,6 @@ const rootClasses = defineClasses(
         null,
         computed(() => props.disabled),
     ],
-    ["modalClass", "o-popover--modal", null, computed(() => props.modal)],
     ["activeClass", "o-popover--active", null, isActive],
     [
         "teleportClass",
@@ -184,6 +183,12 @@ const rootClasses = defineClasses(
 const contentClasses = defineClasses(
     ["contentClass", "o-popover__content"],
     ["contentActiveClass", "o-popover__content--active", null, isActive],
+    [
+        "contentModalClass",
+        "o-popover__content--modal",
+        null,
+        computed(() => props.modal),
+    ],
     [
         "contentBackdropClass",
         "o-popover__content--backdrop",

--- a/packages/oruga/src/components/popover/examples/inspector.vue
+++ b/packages/oruga/src/components/popover/examples/inspector.vue
@@ -7,15 +7,6 @@ const inspectData: InspectData<PopoverClasses, PopoverProps> = {
         class: "rootClass",
         description: "Class of the root element.",
     },
-    modalClass: {
-        class: "modalClass",
-        description: "Class of the root element when shown as modal.",
-        properties: ["modal"],
-        action: (data): void => {
-            data.modal = true;
-            data.active = true;
-        },
-    },
     disabledClass: {
         class: "disabledClass",
         description: "Class of the root element when disabled.",
@@ -53,6 +44,15 @@ const inspectData: InspectData<PopoverClasses, PopoverProps> = {
         description: "Class of the content element when active.",
         properties: ["active"],
         action: (data): void => {
+            data.active = true;
+        },
+    },
+    contentModalClass: {
+        class: "contentModalClass",
+        description: "Class of the content element when shown as modal.",
+        properties: ["modal"],
+        action: (data): void => {
+            data.modal = true;
             data.active = true;
         },
     },

--- a/packages/oruga/src/components/popover/props.ts
+++ b/packages/oruga/src/components/popover/props.ts
@@ -86,8 +86,6 @@ export type PopoverClasses = Partial<{
     rootClass: ComponentClass;
     /** Class of the root element when disabled */
     disabledClass: ComponentClass;
-    /** Class of the root element when shown as modal */
-    modalClass: ComponentClass;
     /** Class for the root element when active  */
     activeClass: ComponentClass;
     /** Class of the root element when teleported */
@@ -98,6 +96,8 @@ export type PopoverClasses = Partial<{
     contentClass: ComponentClass;
     /** Class of the content element when active */
     contentActiveClass: ComponentClass;
+    /** Class of the content element when shown as modal */
+    contentModalClass: ComponentClass;
     /** Class of the content element when should has a backdrop */
     contentBackdropClass: ComponentClass;
     /** Class of the close element */

--- a/packages/oruga/src/components/timepicker/Timepicker.vue
+++ b/packages/oruga/src/components/timepicker/Timepicker.vue
@@ -589,7 +589,6 @@ const rootClasses = defineClasses(
         computed(() => props.expanded),
     ],
     ["mobileClass", "o-timepicker--mobile", null, isMobile],
-    ["modalClass", "o-timepicker--modal", null, isModal],
     ["activeClass", "o-timepicker--active", null, isActive],
     [
         "teleportClass",
@@ -603,6 +602,7 @@ const triggerClasses = defineClasses(["triggerClass", "o-timepicker__trigger"]);
 const contentClasses = defineClasses(
     ["contentClass", "o-timepicker__content"],
     ["contentActiveClass", "o-timepicker__content--active", null, isActive],
+    ["contentModalClass", "o-timepicker__content--modal", null, isModal],
     ["contentBackdropClass", "o-timepicker__content--backdrop", null, isModal],
 );
 

--- a/packages/oruga/src/components/timepicker/examples/inspector.vue
+++ b/packages/oruga/src/components/timepicker/examples/inspector.vue
@@ -12,16 +12,6 @@ const inspectData: InspectData<TimepickerClasses, TimepickerProps> = {
         description: "Class of the root element when on mobile.",
         info: "Switch to mobile view to see it in action!",
     },
-    modalClass: {
-        class: "modalClass",
-        description: "Class of the root element when shown as modal.",
-        properties: ["mobileModal", "desktopModal"],
-        action: (data): void => {
-            data.mobileModal = true;
-            data.desktopModal = true;
-            data.active = true;
-        },
-    },
     teleportClass: {
         class: "teleportClass",
         description: "Class of the root element when teleported.",
@@ -75,6 +65,16 @@ const inspectData: InspectData<TimepickerClasses, TimepickerProps> = {
             "Class of the box container element where you choose the date.",
         action: (data): void => {
             data.inline = true;
+            data.active = true;
+        },
+    },
+    contentModalClass: {
+        class: "contentModalClass",
+        description: "Class of the content element when shown as modal.",
+        properties: ["mobileModal", "desktopModal"],
+        action: (data): void => {
+            data.mobileModal = true;
+            data.desktopModal = true;
             data.active = true;
         },
     },

--- a/packages/oruga/src/components/timepicker/props.ts
+++ b/packages/oruga/src/components/timepicker/props.ts
@@ -106,8 +106,6 @@ export type TimepickerClasses = Partial<{
     rootClass: ComponentClass;
     /** Class of the root element when on mobile */
     mobileClass: ComponentClass;
-    /** Class of the root element when shown as modal */
-    modalClass: ComponentClass;
     /** Class of the root element when teleported */
     teleportClass: ComponentClass;
     /** Class of the root element when disabled */
@@ -124,6 +122,8 @@ export type TimepickerClasses = Partial<{
     contentClass: ComponentClass;
     /** Class of the content element when active or inline */
     contentActiveClass: ComponentClass;
+    /** Class of the content element when shown as modal */
+    contentModalClass: ComponentClass;
     /** Class of the content element when should has a backdrop */
     contentBackdropClass: ComponentClass;
     /** Class of the select separator element */

--- a/packages/oruga/src/config.d.ts
+++ b/packages/oruga/src/config.d.ts
@@ -654,10 +654,6 @@ In addition, any CSS selector string or an actual DOM node can be used.
                  */
                 mobileClass: ClassDefinition;
                 /**
-                 * Class of the root element when shown as modal
-                 */
-                modalClass: ClassDefinition;
-                /**
                  * Class of the root element when teleported
                  */
                 teleportClass: ClassDefinition;
@@ -689,6 +685,10 @@ In addition, any CSS selector string or an actual DOM node can be used.
                  * Class of the content element when active or inline
                  */
                 contentActiveClass: ClassDefinition;
+                /**
+                 * Class of the content element when shown as modal
+                 */
+                contentModalClass: ClassDefinition;
                 /**
                  * Class of the content element when should has a backdrop
                  */
@@ -1215,10 +1215,6 @@ but will set the body to a fixed position, which may break some layouts.
                  */
                 mobileClass: ClassDefinition;
                 /**
-                 * Class of the root element when shown as modal
-                 */
-                modalClass: ClassDefinition;
-                /**
                  * Class of the root element when teleported
                  */
                 teleportClass: ClassDefinition;
@@ -1254,6 +1250,10 @@ but will set the body to a fixed position, which may break some layouts.
                  * Class of the content element when active
                  */
                 contentActiveClass: ClassDefinition;
+                /**
+                 * Class of the content element when shown as modal
+                 */
+                contentModalClass: ClassDefinition;
                 /**
                  * Class of the content element when should has a backdrop
                  */
@@ -2130,10 +2130,6 @@ In addition, any CSS selector string or an actual DOM node can be used.
                  */
                 disabledClass: ClassDefinition;
                 /**
-                 * Class of the root element when shown as modal
-                 */
-                modalClass: ClassDefinition;
-                /**
                  * Class for the root element when active
                  */
                 activeClass: ClassDefinition;
@@ -2153,6 +2149,10 @@ In addition, any CSS selector string or an actual DOM node can be used.
                  * Class of the content element when active
                  */
                 contentActiveClass: ClassDefinition;
+                /**
+                 * Class of the content element when shown as modal
+                 */
+                contentModalClass: ClassDefinition;
                 /**
                  * Class of the content element when should has a backdrop
                  */
@@ -3470,10 +3470,6 @@ In addition, any CSS selector string or an actual DOM node can be used.
                  */
                 mobileClass: ClassDefinition;
                 /**
-                 * Class of the root element when shown as modal
-                 */
-                modalClass: ClassDefinition;
-                /**
                  * Class of the root element when teleported
                  */
                 teleportClass: ClassDefinition;
@@ -3505,6 +3501,10 @@ In addition, any CSS selector string or an actual DOM node can be used.
                  * Class of the content element when active or inline
                  */
                 contentActiveClass: ClassDefinition;
+                /**
+                 * Class of the content element when shown as modal
+                 */
+                contentModalClass: ClassDefinition;
                 /**
                  * Class of the content element when should has a backdrop
                  */


### PR DESCRIPTION
## Proposed Changes

- Change the `modalClass` to `contentModalClass` for all Popover API based components to match where the styles are needed.