### PR TITLE
feat(slider): add a `tickBeforeClass` and `tickAfterClass` class

### DIFF
--- a/packages/oruga/src/components/slider/Slider.vue
+++ b/packages/oruga/src/components/slider/Slider.vue
@@ -155,12 +155,10 @@ function setValues(newValue: number | number[] | undefined): void {
         valueStart.value = isThumbReversed.value ? largeValue : smallValue;
         valueEnd.value = isThumbReversed.value ? smallValue : largeValue;
     } else if (newValue !== undefined) {
-        const value = isNaN(newValue)
+        valueStart.value = isNaN(newValue)
             ? props.min
             : Math.min(props.max, Math.max(props.min, newValue));
-
-        valueStart.value = value;
-        valueEnd.value = value;
+        valueEnd.value = 0;
     } else {
         valueStart.value = props.min;
         valueEnd.value = props.min;

--- a/packages/oruga/src/components/slider/Slider.vue
+++ b/packages/oruga/src/components/slider/Slider.vue
@@ -85,7 +85,7 @@ const provideData = computed<SliderComponent>(() => ({
     max: props.max,
     min: props.min,
     valueStart: valueStart.value,
-    valueEnd: valueEnd.value,
+    valueEnd: Math.max(valueEnd.value, valueStart.value),
 }));
 
 /** provide functionalities and data to child item components */

--- a/packages/oruga/src/components/slider/Slider.vue
+++ b/packages/oruga/src/components/slider/Slider.vue
@@ -84,6 +84,8 @@ const thumbEndRef = useTemplateRef("thumbEndComponent");
 const provideData = computed<SliderComponent>(() => ({
     max: props.max,
     min: props.min,
+    valueStart: valueStart.value,
+    valueEnd: valueEnd.value,
 }));
 
 /** provide functionalities and data to child item components */
@@ -260,7 +262,7 @@ const trackClasses = defineClasses(["trackClass", "o-slider__track"]);
 const fillClasses = defineClasses(
     ["fillClass", "o-slider__fill"],
     [
-        "variantClass",
+        "fillVariantClass",
         "o-slider__fill--",
         computed(() => props.variant),
         computed(() => !!props.variant),

--- a/packages/oruga/src/components/slider/Slider.vue
+++ b/packages/oruga/src/components/slider/Slider.vue
@@ -85,7 +85,7 @@ const provideData = computed<SliderComponent>(() => ({
     max: props.max,
     min: props.min,
     valueStart: valueStart.value,
-    valueEnd: valueEnd.value ?? valueStart.value,
+    valueEnd: valueEnd.value,
 }));
 
 /** provide functionalities and data to child item components */
@@ -149,10 +149,12 @@ function setValues(newValue: number | number[] | undefined): void {
         valueStart.value = isThumbReversed.value ? largeValue : smallValue;
         valueEnd.value = isThumbReversed.value ? smallValue : largeValue;
     } else if (newValue !== undefined) {
-        valueStart.value = isNaN(newValue)
+        const value = isNaN(newValue)
             ? props.min
             : Math.min(props.max, Math.max(props.min, newValue));
-        valueEnd.value = 0;
+
+        valueStart.value = value;
+        valueEnd.value = value;
     } else {
         valueStart.value = props.min;
         valueEnd.value = props.min;
@@ -162,7 +164,7 @@ function setValues(newValue: number | number[] | undefined): void {
 const tickValues = computed(() => {
     if (!props.ticks || props.min > props.max || props.step === 0) return [];
     const result: number[] = [];
-    for (let i = props.min + props.step; i < props.max; i = i + props.step) {
+    for (let i = props.min; i <= props.max; i = i + props.step) {
         result.push(i);
     }
     return result;

--- a/packages/oruga/src/components/slider/Slider.vue
+++ b/packages/oruga/src/components/slider/Slider.vue
@@ -85,7 +85,7 @@ const provideData = computed<SliderComponent>(() => ({
     max: props.max,
     min: props.min,
     valueStart: valueStart.value,
-    valueEnd: valueEnd.value,
+    valueEnd: valueEnd.value ?? valueStart.value,
 }));
 
 /** provide functionalities and data to child item components */

--- a/packages/oruga/src/components/slider/SliderTick.vue
+++ b/packages/oruga/src/components/slider/SliderTick.vue
@@ -59,7 +59,9 @@ const hidden = computed(
 const tickStyle = computed(() => ({ left: position.value + "%" }));
 
 const isBefore = computed(() => parent.value.valueStart > props.value);
-const isAfter = computed(() => parent.value.valueEnd > props.value);
+const isAfter = computed(
+    () => (parent.value.valueEnd ?? parent.value.valueStart) > props.value,
+);
 
 // #region --- Computed Component Classes ---
 

--- a/packages/oruga/src/components/slider/SliderTick.vue
+++ b/packages/oruga/src/components/slider/SliderTick.vue
@@ -60,7 +60,7 @@ const tickStyle = computed(() => ({ left: position.value + "%" }));
 
 const isBefore = computed(() => parent.value.valueStart > props.value);
 const isAfter = computed(
-    () => (parent.value.valueEnd ?? parent.value.valueStart) > props.value,
+    () => (parent.value.valueEnd ?? parent.value.valueStart) < props.value,
 );
 
 // #region --- Computed Component Classes ---

--- a/packages/oruga/src/components/slider/SliderTick.vue
+++ b/packages/oruga/src/components/slider/SliderTick.vue
@@ -58,11 +58,16 @@ const hidden = computed(
 
 const tickStyle = computed(() => ({ left: position.value + "%" }));
 
+const isBefore = computed(() => parent.value.valueStart > props.value);
+const isAfter = computed(() => parent.value.valueEnd > props.value);
+
 // #region --- Computed Component Classes ---
 
 const rootClasses = defineClasses(
     ["tickClass", "o-slider__tick"],
     ["tickHiddenClass", "o-slider__tick--hidden", null, hidden],
+    ["tickBeforeClass", "o-slider__tick--before", null, isBefore],
+    ["tickAfterClass", "o-slider__tick--after", null, isAfter],
 );
 
 const tickLabelClasses = defineClasses([
@@ -80,7 +85,7 @@ const tickLabelClasses = defineClasses([
         :class="rootClasses"
         :style="tickStyle">
         <span v-if="$slots.default || label" :class="tickLabelClasses">
-            <!-- 
+            <!--
                 @slot Override tick content, default is label prop
              -->
             <slot> {{ label }} </slot>

--- a/packages/oruga/src/components/slider/SliderTick.vue
+++ b/packages/oruga/src/components/slider/SliderTick.vue
@@ -87,7 +87,6 @@ const tickLabelClasses = defineClasses([
         :class="rootClasses"
         :style="tickStyle">
         <span v-if="$slots.default || label" :class="tickLabelClasses">
-            {{ parent.valueStart }} {{ parent.valueEnd }}
             <!--
                 @slot Override tick content, default is label prop
              -->

--- a/packages/oruga/src/components/slider/SliderTick.vue
+++ b/packages/oruga/src/components/slider/SliderTick.vue
@@ -82,10 +82,10 @@ const tickLabelClasses = defineClasses([
     <div
         ref="rootElement"
         data-oruga="slider-tick"
-        :data-value="value"
-        aria-hidden="true"
         :class="rootClasses"
-        :style="tickStyle">
+        :style="tickStyle"
+        :data-value="value"
+        aria-hidden="true">
         <span v-if="$slots.default || label" :class="tickLabelClasses">
             <!--
                 @slot Override tick content, default is label prop

--- a/packages/oruga/src/components/slider/SliderTick.vue
+++ b/packages/oruga/src/components/slider/SliderTick.vue
@@ -82,9 +82,12 @@ const tickLabelClasses = defineClasses([
     <div
         ref="rootElement"
         data-oruga="slider-tick"
+        :data-value="value"
+        aria-hidden="true"
         :class="rootClasses"
         :style="tickStyle">
         <span v-if="$slots.default || label" :class="tickLabelClasses">
+            {{ parent.valueStart }} {{ parent.valueEnd }}
             <!--
                 @slot Override tick content, default is label prop
              -->

--- a/packages/oruga/src/components/slider/SliderTick.vue
+++ b/packages/oruga/src/components/slider/SliderTick.vue
@@ -59,9 +59,7 @@ const hidden = computed(
 const tickStyle = computed(() => ({ left: position.value + "%" }));
 
 const isBefore = computed(() => parent.value.valueStart > props.value);
-const isAfter = computed(
-    () => (parent.value.valueEnd ?? parent.value.valueStart) < props.value,
-);
+const isAfter = computed(() => parent.value.valueEnd < props.value);
 
 // #region --- Computed Component Classes ---
 

--- a/packages/oruga/src/components/slider/examples/inspector.vue
+++ b/packages/oruga/src/components/slider/examples/inspector.vue
@@ -2,7 +2,7 @@
 import type { InspectData } from "@docs";
 import type { SliderClasses, SliderProps } from "../props";
 
-const inspectData: InspectData<SliderClasses, SliderProps<true | false>> = {
+const inspectData: InspectData<SliderClasses, SliderProps> = {
     rootClass: {
         class: "rootClass",
         description: "Class of the root element.",

--- a/packages/oruga/src/components/slider/examples/inspector.vue
+++ b/packages/oruga/src/components/slider/examples/inspector.vue
@@ -2,7 +2,7 @@
 import type { InspectData } from "@docs";
 import type { SliderClasses, SliderProps } from "../props";
 
-const inspectData: InspectData<SliderClasses, SliderProps> = {
+const inspectData: InspectData<SliderClasses, SliderProps<true | false>> = {
     rootClass: {
         class: "rootClass",
         description: "Class of the root element.",
@@ -32,8 +32,8 @@ const inspectData: InspectData<SliderClasses, SliderProps> = {
         class: "fillClass",
         description: "Class of the filled part of the slider.",
     },
-    variantClass: {
-        class: "variantClass",
+    fillVariantClass: {
+        class: "fillVariantClass",
         description: "Class of the filled part of the slider with variant",
         properties: ["variant"],
         suffixes: ["primary", "info", "warning", "danger"],
@@ -78,6 +78,20 @@ const inspectData: InspectData<SliderClasses, SliderProps> = {
         class: "tickHiddenClass",
         subitem: "slidertick",
         description: "Class of the slider tick element when is hidden.",
+        properties: ["ticks"],
+    },
+    tickBeforeClass: {
+        class: "tickBeforeClass",
+        subitem: "slidertick",
+        description:
+            "Class of the slider tick element when is before the value.",
+        properties: ["ticks"],
+    },
+    tickAfterClass: {
+        class: "tickAfterClass",
+        subitem: "slidertick",
+        description:
+            "Class of the slider tick element when is before the value.",
         properties: ["ticks"],
     },
     tickLabelClass: {

--- a/packages/oruga/src/components/slider/props.ts
+++ b/packages/oruga/src/components/slider/props.ts
@@ -1,6 +1,6 @@
 import type { ComponentClass } from "@/types";
 
-export type SliderProps<IsRange extends boolean> = {
+export type SliderProps<IsRange extends boolean = false> = {
     /** Override existing theme classes completely */
     override?: boolean;
     /** The input value state, use v-model to make it two-way binding */

--- a/packages/oruga/src/components/slider/props.ts
+++ b/packages/oruga/src/components/slider/props.ts
@@ -1,6 +1,6 @@
 import type { ComponentClass } from "@/types";
 
-export type SliderProps<IsRange extends boolean = false> = {
+export type SliderProps<IsRange extends boolean> = {
     /** Override existing theme classes completely */
     override?: boolean;
     /** The input value state, use v-model to make it two-way binding */
@@ -70,7 +70,7 @@ export type SliderClasses = Partial<{
     /** Class of the filled part of the slider */
     fillClass: ComponentClass;
     /** Class of the filled part of the slider with variant */
-    variantClass: ComponentClass;
+    fillVariantClass: ComponentClass;
     /** Class of the thumb wrapper element */
     thumbWrapperClass: ComponentClass;
     /** Class to the thumb wrapper element when the slider is dragged */
@@ -85,6 +85,10 @@ export type SliderClasses = Partial<{
     tickClass: ComponentClass;
     /** Class of the slider tick element when is hidden */
     tickHiddenClass: ComponentClass;
+    /** Class of the slider tick element when is before the value */
+    tickBeforeClass: ComponentClass;
+    /** Class of the slider tick element when is after the value */
+    tickAfterClass: ComponentClass;
     /** Class of the slider tick label element */
     tickLabelClass: ComponentClass;
 }>;

--- a/packages/oruga/src/components/slider/tests/slider.unit.test.ts
+++ b/packages/oruga/src/components/slider/tests/slider.unit.test.ts
@@ -50,7 +50,7 @@ describe("OSlider tests", () => {
             props: { ticks: true, min: 0, max: 100, step: 10 },
         });
 
-        expect(wrapper.findAll('[data-oruga="slider-tick"]')).toHaveLength(9);
+        expect(wrapper.findAll('[data-oruga="slider-tick"]')).toHaveLength(11);
     });
 
     test("emits a change event when a thumb is moved with keyboard input", async () => {

--- a/packages/oruga/src/components/slider/tests/slider.unit.test.ts
+++ b/packages/oruga/src/components/slider/tests/slider.unit.test.ts
@@ -13,4 +13,54 @@ describe("OSlider tests", () => {
         expect(wrapper.attributes("data-oruga")).toBe("slider");
         expect(wrapper.html()).toMatchSnapshot();
     });
+
+    test("renders a single thumb with the expected classes and aria attributes", () => {
+        const wrapper = mount(OSlider, {
+            props: { modelValue: 30, size: "large", variant: "danger" },
+        });
+
+        expect(wrapper.find(".o-slider__track").exists()).toBe(true);
+        expect(wrapper.find(".o-slider__fill").exists()).toBe(true);
+        expect(wrapper.findAll('[data-oruga="slider-thumb"]')).toHaveLength(1);
+        expect(
+            wrapper.find('[role="slider"]').attributes("aria-valuenow"),
+        ).toBe("30");
+        expect(
+            wrapper.find('[role="slider"]').attributes("aria-disabled"),
+        ).toBe("false");
+        expect(wrapper.classes()).toContain("o-slider--large");
+    });
+
+    test("renders two thumbs for range sliders and updates the exposed value", async () => {
+        const wrapper = mount(OSlider, {
+            props: { range: true, modelValue: [20, 80], min: 0, max: 100 },
+        });
+
+        expect(wrapper.findAll('[data-oruga="slider-thumb"]')).toHaveLength(2);
+        expect(wrapper.findAll('[role="slider"]')).toHaveLength(2);
+        expect(wrapper.vm.value).toEqual([20, 80]);
+
+        await wrapper.setProps({ modelValue: [30, 70] });
+
+        expect(wrapper.vm.value).toEqual([30, 70]);
+    });
+
+    test("renders ticks when enabled", () => {
+        const wrapper = mount(OSlider, {
+            props: { ticks: true, min: 0, max: 100, step: 10 },
+        });
+
+        expect(wrapper.findAll('[data-oruga="slider-tick"]')).toHaveLength(9);
+    });
+
+    test("emits a change event when a thumb is moved with keyboard input", async () => {
+        const wrapper = mount(OSlider, {
+            props: { modelValue: 30, step: 1 },
+        });
+
+        await wrapper.find('[role="slider"]').trigger("keydown.right");
+
+        expect(wrapper.emitted("change")).toBeTruthy();
+        expect(wrapper.emitted("change")?.[0]?.[0]).toBeGreaterThan(30);
+    });
 });

--- a/packages/oruga/src/components/slider/types.ts
+++ b/packages/oruga/src/components/slider/types.ts
@@ -1,4 +1,6 @@
 export type SliderComponent = {
     min: number;
     max: number;
+    valueStart: number;
+    valueEnd: number;
 };

--- a/packages/oruga/src/config.d.ts
+++ b/packages/oruga/src/config.d.ts
@@ -2511,7 +2511,7 @@ In addition, any CSS selector string or an actual DOM node can be used.
                 /**
                  * Class of the filled part of the slider with variant
                  */
-                variantClass: ClassDefinition;
+                fillVariantClass: ClassDefinition;
                 /**
                  * Class of the thumb wrapper element
                  */
@@ -2540,6 +2540,14 @@ In addition, any CSS selector string or an actual DOM node can be used.
                  * Class of the slider tick element when is hidden
                  */
                 tickHiddenClass: ClassDefinition;
+                /**
+                 * Class of the slider tick element when is before the value
+                 */
+                tickBeforeClass: ClassDefinition;
+                /**
+                 * Class of the slider tick element when is after the value
+                 */
+                tickAfterClass: ClassDefinition;
                 /**
                  * Class of the slider tick label element
                  */


### PR DESCRIPTION
## Proposed Changes

- Add a `tickBeforeClass` and `tickAfterClass` to a tick when `ticks` are enabled on the OSlider component.
  - The `tickBeforeClass` is shown when the value is before the start value.
  - The `tickAfterClass` is shown when the value is after the end value.
- Change OSlider `variantClass` to `fillVariantClass` to match its relation.
- Also added more OSlider tests.

BREAKING CHANGE: The `variantClass` changed to `fillVariantClass` in the OSlider component to match its relation.
