### PR TITLE
refactor: change generic boolean prop defaults form `false` to `boolean`

### DIFF
--- a/packages/oruga/src/components/checkbox/props.ts
+++ b/packages/oruga/src/components/checkbox/props.ts
@@ -1,6 +1,6 @@
 import type { ComponentClass } from "@/types";
 
-export type CheckboxProps<T, IsMultiple extends boolean = false> = {
+export type CheckboxProps<T, IsMultiple extends boolean = boolean> = {
     /** Override existing theme classes completely */
     override?: boolean;
     /** The input value state, use v-model to make it two-way binding */

--- a/packages/oruga/src/components/datepicker/props.ts
+++ b/packages/oruga/src/components/datepicker/props.ts
@@ -10,8 +10,8 @@ type DatepickerType<IsRange, IsMultiple> = IsRange extends true
       : Date;
 
 export type DatepickerProps<
-    IsRange extends boolean = false,
-    IsMultiple extends boolean = false,
+    IsRange extends boolean = boolean,
+    IsMultiple extends boolean = boolean,
 > = {
     /** Override existing theme classes completely */
     override?: boolean;

--- a/packages/oruga/src/components/dropdown/props.ts
+++ b/packages/oruga/src/components/dropdown/props.ts
@@ -5,7 +5,7 @@ type ValueType<T, IsMultiple> = IsMultiple extends true ? T[] : T;
 
 export type DropdownOptions<T> = OptionsOrGroupsProp<DropdownItemProps<T>>;
 
-export type DropdownProps<T, IsMultiple extends boolean = false> = {
+export type DropdownProps<T, IsMultiple extends boolean = boolean> = {
     /** Override existing theme classes completely */
     override?: boolean;
     /** The selected option value, use v-model to make it two-way binding */

--- a/packages/oruga/src/components/input/props.ts
+++ b/packages/oruga/src/components/input/props.ts
@@ -4,7 +4,7 @@ export type InputType<IsNumber extends boolean> = IsNumber extends true
     ? number
     : string;
 
-export type InputProps<IsNumber extends boolean = false> = {
+export type InputProps<IsNumber extends boolean = boolean> = {
     /** Override existing theme classes completely */
     override?: boolean;
     /**

--- a/packages/oruga/src/components/listbox/props.ts
+++ b/packages/oruga/src/components/listbox/props.ts
@@ -5,7 +5,7 @@ type ValueType<T, IsMultiple> = IsMultiple extends true ? T[] : T;
 
 export type ListboxOptions<T> = OptionsOrGroupsProp<ListItemProps<T>>;
 
-export type ListboxProps<T, IsMultiple extends boolean = false> = {
+export type ListboxProps<T, IsMultiple extends boolean = boolean> = {
     /** Override existing theme classes completely */
     override?: boolean;
     /**

--- a/packages/oruga/src/components/select/props.ts
+++ b/packages/oruga/src/components/select/props.ts
@@ -10,7 +10,7 @@ export type SelectOption<T = string | number> = {
 
 export type SelectOptions<T> = OptionsOrGroupsProp<SelectOption<T>>;
 
-export type SelectProps<T, IsMultiple extends boolean = false> = {
+export type SelectProps<T, IsMultiple extends boolean = boolean> = {
     /** Override existing theme classes completely */
     override?: boolean;
     /** The input value state, use v-model to make it two-way binding */

--- a/packages/oruga/src/components/slider/props.ts
+++ b/packages/oruga/src/components/slider/props.ts
@@ -1,6 +1,6 @@
 import type { ComponentClass } from "@/types";
 
-export type SliderProps<IsRange extends boolean = false> = {
+export type SliderProps<IsRange extends boolean = boolean> = {
     /** Override existing theme classes completely */
     override?: boolean;
     /** The input value state, use v-model to make it two-way binding */

--- a/packages/oruga/src/components/tree/props.ts
+++ b/packages/oruga/src/components/tree/props.ts
@@ -5,7 +5,7 @@ type ValueType<T, IsMultiple> = IsMultiple extends true ? T[] : T;
 
 export type TreeOptions<T> = OptionsProp<TreeItemProps<T>>;
 
-export type TreeProps<T, IsMultiple extends boolean = false> = {
+export type TreeProps<T, IsMultiple extends boolean = boolean> = {
     /** Override existing theme classes completely */
     override?: boolean;
     /** The selected item value, use v-model to make it two-way binding */

--- a/packages/oruga/src/components/upload/props.ts
+++ b/packages/oruga/src/components/upload/props.ts
@@ -4,7 +4,7 @@ type UploadType<T, IsMultiple> = IsMultiple extends true ? T[] : T;
 
 export type UploadProps<
     T extends object | typeof File,
-    IsMultiple extends boolean = false,
+    IsMultiple extends boolean = boolean,
 > = {
     /** Override existing theme classes completely */
     override?: boolean;


### PR DESCRIPTION
## Proposed Changes

Some components with generic `Props` types have Boolean generics with a 'false' default. 
I changed this to a more generic `boolean` default, meaning that the inherited properties are more accurate without the need for a more detailed specification of the generic value.
