### PR TITLE
fix(tabs): correctly export TabsProps and TabItemProps types

### DIFF
--- a/packages/oruga/src/components/tabs/index.ts
+++ b/packages/oruga/src/components/tabs/index.ts
@@ -7,6 +7,7 @@ import { registerComponent } from "@/utils/plugins";
 import type { OrugaComponentPlugin } from "@/utils/config";
 
 /** export tabs specific types */
+export type * from "./props";
 export type * from "./types";
 
 /** export tabs plugin */


### PR DESCRIPTION
## Proposed Changes

- The export for the TabsProp and TabItemProps types were missing.