### PR TITLE
feat(upload): redefine drag/drop class name

### DIFF
--- a/packages/oruga/src/components/upload/Upload.vue
+++ b/packages/oruga/src/components/upload/Upload.vue
@@ -229,15 +229,17 @@ const rootClasses = defineClasses(
     ],
 );
 
-const draggableClasses = defineClasses(
-    ["draggableClass", "o-upload__draggable"],
+const dragzoneClasses = defineClasses(
+    ["dragzoneClass", "o-upload__dragzone"],
     [
-        "draggableHoveredClass",
-        "o-upload__draggable--hovered",
+        "dragzoneHoveredClass",
+        "o-upload__dragzone--hovered",
         null,
         computed(() => dragDropFocus.value),
     ],
 );
+
+const inputClasses = defineClasses(["inputClass", "o-upload__input"]);
 
 // #endregion --- Computed Component Classes ---
 
@@ -262,7 +264,7 @@ defineExpose({
 
         <div
             v-else
-            :class="draggableClasses"
+            :class="dragzoneClasses"
             role="button"
             tabindex="0"
             @pointerenter="updateDragDropFocus(true)"
@@ -277,6 +279,7 @@ defineExpose({
         <input
             v-bind="inputBind"
             ref="inputElement"
+            :class="inputClasses"
             type="file"
             data-oruga-input="file"
             :multiple="props.multiple"

--- a/packages/oruga/src/components/upload/examples/drag-drop.vue
+++ b/packages/oruga/src/components/upload/examples/drag-drop.vue
@@ -22,7 +22,7 @@ function deleteDropFile(index): void {
         </o-field>
 
         <div class="tags">
-            <span v-for="(file, index) in dropFiles" :key="index">
+            <span v-for="(file, index) in dropFiles" :key="file.name">
                 {{ file.name }}
                 <o-button
                     icon-left="times"

--- a/packages/oruga/src/components/upload/examples/inspector.vue
+++ b/packages/oruga/src/components/upload/examples/inspector.vue
@@ -34,17 +34,18 @@ const inspectData: InspectData<UploadClasses, UploadProps<File>> = {
             data.dragDrop = true;
         },
     },
-    draggableClass: {
-        class: "draggableClass",
-        description: "Class of the dragable container element.",
+    dragzoneClass: {
+        class: "dragzoneClass",
+        description: "Class of the drag/drop container element.",
         properties: ["dragDrop"],
         action: (data): void => {
             data.dragDrop = true;
         },
     },
-    draggableHoveredClass: {
-        class: "draggableHoveredClass",
-        description: "Class of the dragable container element when hovered.",
+    dragzoneHoveredClass: {
+        class: "dragzoneHoveredClass",
+        description:
+            "Class of the dragable container element when hovered with a file.",
         info: "Drag & drop a file to see it in action!",
         properties: ["dragDrop"],
         action: (data): void => {

--- a/packages/oruga/src/components/upload/props.ts
+++ b/packages/oruga/src/components/upload/props.ts
@@ -51,8 +51,8 @@ export type UploadClasses = Partial<{
     disabledClass: ComponentClass;
     /** Class of the root element with variant */
     variantClass: ComponentClass;
-    /** Class of the dragable container element */
-    draggableClass: ComponentClass;
-    /** Class of the dragable container element when hovered */
-    draggableHoveredClass: ComponentClass;
+    /** Class of the drag/drop container element */
+    dragzoneClass: ComponentClass;
+    /** Class of the drag/drop container element when hovered with a file*/
+    dragzoneHoveredClass: ComponentClass;
 }>;

--- a/packages/oruga/src/components/upload/tests/__snapshots__/upload.unit.test.ts.snap
+++ b/packages/oruga/src/components/upload/tests/__snapshots__/upload.unit.test.ts.snap
@@ -1,3 +1,3 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`OUpload tests > render correctly 1`] = `"<label data-oruga="upload" class="o-upload"><input type="file" data-oruga-input="file"></label>"`;
+exports[`OUpload tests > render correctly 1`] = `"<label data-oruga="upload" class="o-upload"><input class="o-upload__input" type="file" data-oruga-input="file"></label>"`;

--- a/packages/oruga/src/config.d.ts
+++ b/packages/oruga/src/config.d.ts
@@ -3773,13 +3773,13 @@ In addition, any CSS selector string or an actual DOM node can be used.
                  */
                 variantClass: ClassDefinition;
                 /**
-                 * Class of the dragable container element
+                 * Class of the drag/drop container element
                  */
-                draggableClass: ClassDefinition;
+                dragzoneClass: ClassDefinition;
                 /**
-                 * Class of the dragable container element when hovered
+                 * Class of the drag/drop container element when hovered with a file
                  */
-                draggableHoveredClass: ClassDefinition;
+                dragzoneHoveredClass: ClassDefinition;
             }>;
     }
 }


### PR DESCRIPTION
## Proposed Changes

- Change class name from "draggableClass" to "dragzoneClass" to better match is usecase.
- Add "inputClass" to apply to the underlying input element.

BREAKING CHANGE: The class property "draggableClass" of the OUpload component got renamed to "dragzoneClass".