### PR TITLE
fix(popover): correctly apply position change

### DIFF
--- a/packages/oruga/src/components/autocomplete/tests/__snapshots__/autocomplete.unit.test.ts.snap
+++ b/packages/oruga/src/components/autocomplete/tests/__snapshots__/autocomplete.unit.test.ts.snap
@@ -12,7 +12,7 @@ exports[`OAutocomplete tests > render correctly 1`] = `
     </div>
     <!--teleport start-->
     <transition-stub name="fade" appear="false" persisted="false" css="true">
-      <div id="v-0" tabindex="-1" class="o-dropdown__menu o-dropdown__content" style="max-height: 200px; overflow: auto; display: none; position-area: bottom; position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;" role="listbox" aria-multiselectable="false" popover="" data-position="bottom">
+      <div id="v-0" tabindex="-1" class="o-dropdown__menu o-dropdown__content" style="max-height: 200px; overflow: auto; position-area: bottom; position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline; display: none;" role="listbox" aria-multiselectable="false" popover="" data-position="bottom">
         <div id="v-0-1" data-oruga="dropdown-item" data-id="dropdown-1" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" tabindex="-1" aria-selected="false" aria-hidden="false" aria-disabled="false"><span>Angular</span></div>
         <div id="v-0-2" data-oruga="dropdown-item" data-id="dropdown-2" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" tabindex="-1" aria-selected="false" aria-hidden="false" aria-disabled="false"><span>Angular 2</span></div>
         <div id="v-0-3" data-oruga="dropdown-item" data-id="dropdown-3" class="o-dropdown__item o-dropdown__item--clickable o-autocomplete__item" role="option" tabindex="-1" aria-selected="false" aria-hidden="false" aria-disabled="false"><span>Aurelia</span></div>

--- a/packages/oruga/src/components/datepicker/tests/__snapshots__/datepicker.unit.test.ts.snap
+++ b/packages/oruga/src/components/datepicker/tests/__snapshots__/datepicker.unit.test.ts.snap
@@ -12,7 +12,7 @@ exports[`ODatepicker > render correctly 1`] = `
   </div>
   <!--teleport start-->
   <transition-stub appear="false" persisted="false" css="true">
-    <div class="o-datepicker__content" popover="" style="display: none; position-area: bottom; position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;" data-position="bottom">
+    <div class="o-datepicker__content" popover="" style="position-area: bottom; position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline; display: none;" data-position="bottom">
       <header class="o-datepicker__header"><button data-oruga="button" type="button" role="button" tabindex="0" class="o-button o-datepicker__header__previous" aria-label="Previous Page"><span data-oruga="icon" class="o-icon o-button__icon o-button__icon-left"><!-- custom icon component --><!-- native css icon --><i class="mdi mdi-chevron-left mdi-24px"></i></span>
           <!--v-if-->
           <!--v-if-->

--- a/packages/oruga/src/components/datetimepicker/tests/__snapshots__/datetimepicker.unit.test.ts.snap
+++ b/packages/oruga/src/components/datetimepicker/tests/__snapshots__/datetimepicker.unit.test.ts.snap
@@ -12,7 +12,7 @@ exports[`ODatetimepicker tests > render correctly 1`] = `
   </div>
   <!--teleport start-->
   <transition-stub appear="false" persisted="false" css="true">
-    <div class="o-datepicker__content" popover="" style="display: none; position-area: bottom; position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;" data-position="bottom">
+    <div class="o-datepicker__content" popover="" style="position-area: bottom; position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline; display: none;" data-position="bottom">
       <header class="o-datepicker__header"><button data-oruga="button" type="button" role="button" tabindex="0" class="o-button o-datepicker__header__previous" aria-label="Previous Page"><span data-oruga="icon" class="o-icon o-button__icon o-button__icon-left"><!-- custom icon component --><!-- native css icon --><i class="mdi mdi-chevron-left mdi-24px"></i></span>
           <!--v-if-->
           <!--v-if-->

--- a/packages/oruga/src/components/dropdown/Dropdown.vue
+++ b/packages/oruga/src/components/dropdown/Dropdown.vue
@@ -210,12 +210,16 @@ const isModal = computed(() =>
     isMobile.value ? props.mobileModal : props.desktopModal,
 );
 
+const popoverPosition = computed(() =>
+    isModal.value ? "centered" : props.position,
+);
+
 const {
     open: openPopover,
     close: closePopover,
     toggle: togglePopover,
 } = usePopoverAPI({
-    position: isModal.value ? "centered" : props.position,
+    position: popoverPosition,
     delay: props.delay,
     behavior: "manual",
     trigger: isActive,

--- a/packages/oruga/src/components/dropdown/tests/__snapshots__/dropdown.unit.test.ts.snap
+++ b/packages/oruga/src/components/dropdown/tests/__snapshots__/dropdown.unit.test.ts.snap
@@ -5,7 +5,7 @@ exports[`ODropdown tests > render correctly with items 1`] = `
   <div class="o-dropdown__trigger" role="combobox" aria-haspopup="listbox" aria-expanded="false" aria-disabled="false" aria-controls="v-0"><button class="">Component Trigger Label</button></div>
   <!--teleport start-->
   <transition-stub name="fade" appear="false" persisted="false" css="true">
-    <div id="v-0" tabindex="-1" class="o-dropdown__menu o-dropdown__content" role="listbox" aria-multiselectable="false" popover="" style="display: none; position-area: bottom; position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;" data-position="bottom">
+    <div id="v-0" tabindex="-1" class="o-dropdown__menu o-dropdown__content" role="listbox" aria-multiselectable="false" popover="" style="position-area: bottom; position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline; display: none;" data-position="bottom">
       <div id="v-0-1" data-oruga="dropdown-item" data-id="dropdown-1" class="o-dropdown__item o-dropdown__item--clickable" role="option" tabindex="-1" aria-selected="false" aria-hidden="false" aria-disabled="false">A</div>
       <div id="v-0-2" data-oruga="dropdown-item" data-id="dropdown-2" class="o-dropdown__item o-dropdown__item--clickable" role="option" tabindex="-1" aria-selected="false" aria-hidden="false" aria-disabled="false">B</div>
       <div id="v-0-3" data-oruga="dropdown-item" data-id="dropdown-3" class="o-dropdown__item o-dropdown__item--clickable" role="option" tabindex="-1" aria-selected="false" aria-hidden="false" aria-disabled="false">C</div>
@@ -21,7 +21,7 @@ exports[`ODropdown tests > render correctly with options 1`] = `
   <div class="o-dropdown__trigger" aria-haspopup="menu" aria-disabled="false">Some Trigger Label</div>
   <!--teleport start-->
   <transition-stub name="fade" appear="false" persisted="false" css="true">
-    <div id="v-0" tabindex="-1" class="o-dropdown__menu o-dropdown__content" role="menu" aria-hidden="false" popover="" style="display: none; position-area: bottom; position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;" data-position="bottom">
+    <div id="v-0" tabindex="-1" class="o-dropdown__menu o-dropdown__content" role="menu" aria-hidden="false" popover="" style="position-area: bottom; position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline; display: none;" data-position="bottom">
       <div id="v-0-1" data-oruga="dropdown-item" data-id="dropdown-1" class="o-dropdown__item o-dropdown__item--clickable" role="menuitem" tabindex="-1" aria-hidden="false" aria-disabled="false"><span>Item 1</span></div>
       <div id="v-0-2" data-oruga="dropdown-item" data-id="dropdown-2" class="o-dropdown__item o-dropdown__item--clickable" role="menuitem" tabindex="-1" aria-hidden="false" aria-disabled="false"><span>Item 2</span></div>
       <div id="v-0-3" data-oruga="dropdown-item" data-id="dropdown-3" class="o-dropdown__item o-dropdown__item--clickable" role="menuitem" tabindex="-1" aria-hidden="false" aria-disabled="false"><span>Item 3</span></div>

--- a/packages/oruga/src/components/popover/Popover.vue
+++ b/packages/oruga/src/components/popover/Popover.vue
@@ -131,11 +131,16 @@ onMounted(() => {
 
 const _teleport = useTeleport(props.teleport);
 
+const popoverPosition = computed(() =>
+    props.modal ? "centered" : props.position,
+);
+
 const { open, close, toggle } = usePopoverAPI({
-    position: props.modal ? "centered" : props.position,
+    position: popoverPosition,
     delay: props.delay,
     behavior: props.behavior,
     trigger: isActive,
+    disabled: () => props.disabled,
     targetTrigger: !props.target,
     targetRef: triggerRef,
     contentRef,

--- a/packages/oruga/src/components/popover/tests/__snapshots__/popover.unit.test.ts.snap
+++ b/packages/oruga/src/components/popover/tests/__snapshots__/popover.unit.test.ts.snap
@@ -5,7 +5,7 @@ exports[`OPopover tests > render correctly 1`] = `
   <p role="button" tabindex="0" aria-controls="v-0"> Open Popover! </p>
   <!--teleport start-->
   <transition-stub name="fade" appear="false" persisted="false" css="true">
-    <div id="v-0" class="o-popover__content" popover="" style="display: none; position-area: top; position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;" data-position="top">
+    <div id="v-0" class="o-popover__content" popover="" style="position-area: top; position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline; display: none;" data-position="top">
       <!--v-if-->
       <!--v-if-->
       <div class="o-popover__body">

--- a/packages/oruga/src/components/taginput/tests/__snapshots__/taginput.unit.test.ts.snap
+++ b/packages/oruga/src/components/taginput/tests/__snapshots__/taginput.unit.test.ts.snap
@@ -14,7 +14,7 @@ exports[`OTaginput tests > render correctly 1`] = `
         </div>
         <!--teleport start-->
         <transition-stub name="fade" appear="false" persisted="false" css="true">
-          <div id="v-0" tabindex="-1" class="o-dropdown__menu o-dropdown__content" style="max-height: 200px; overflow: auto; display: none; position-area: bottom; position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;" role="listbox" aria-multiselectable="false" popover="" data-position="bottom"></div>
+          <div id="v-0" tabindex="-1" class="o-dropdown__menu o-dropdown__content" style="max-height: 200px; overflow: auto; position-area: bottom; position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline; display: none;" role="listbox" aria-multiselectable="false" popover="" data-position="bottom"></div>
         </transition-stub>
         <!--teleport end-->
       </div>

--- a/packages/oruga/src/components/timepicker/tests/__snapshots__/timepicker.unit.test.ts.snap
+++ b/packages/oruga/src/components/timepicker/tests/__snapshots__/timepicker.unit.test.ts.snap
@@ -12,7 +12,7 @@ exports[`OTimepicker tests > render correctly 1`] = `
   </div>
   <!--teleport start-->
   <transition-stub appear="false" persisted="false" css="true">
-    <div class="o-timepicker__content" popover="" style="display: none; position-area: bottom; position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;" data-position="bottom">
+    <div class="o-timepicker__content" popover="" style="position-area: bottom; position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline; display: none;" data-position="bottom">
       <!--v-if-->
       <div class="o-timepicker__body">
         <div data-oruga="select" class="">

--- a/packages/oruga/src/components/utils/PickerInput.vue
+++ b/packages/oruga/src/components/utils/PickerInput.vue
@@ -137,8 +137,12 @@ const _teleport = useTeleport(props.teleport);
 // #region --- PICKER FEATURE ---
 
 if (!props.inline) {
+    const popoverPosition = computed(() =>
+        props.modal ? "centered" : props.position,
+    );
+
     usePopoverAPI({
-        position: props.modal ? "centered" : props.position,
+        position: popoverPosition,
         behavior: "auto",
         trigger: isActive,
         targetRef: triggerRef,

--- a/packages/oruga/src/composables/usePopoverAPI.ts
+++ b/packages/oruga/src/composables/usePopoverAPI.ts
@@ -168,26 +168,29 @@ export function usePopoverAPI(options: PopoverAPIOptions): {
         useEventListener(contentRef, "beforetoggle", options.onBeforeToggle);
 
     // apply position
-    watchEffect(() => {
-        contentEl = unrefElement(contentRef);
-        if (!contentEl) return;
+    watchEffect(
+        () => {
+            contentEl = unrefElement(contentRef);
+            if (!contentEl) return;
 
-        const _position = toValue(position);
+            const _position = toValue(position);
 
-        // add content position styles
-        contentEl.style.positionArea =
-            _position === "centered"
-                ? "none"
-                : Array.isArray(_position)
-                  ? _position.join(" ")
-                  : _position;
+            // add content position styles
+            contentEl.style.positionArea =
+                _position === "centered"
+                    ? "none"
+                    : Array.isArray(_position)
+                      ? _position.join(" ")
+                      : _position;
 
-        contentEl.style.positionTryFallbacks =
-            "flip-block, flip-inline, flip-block flip-inline";
+            contentEl.style.positionTryFallbacks =
+                "flip-block, flip-inline, flip-block flip-inline";
 
-        // add position data attribute
-        contentEl.dataset.position = _position.toString();
-    });
+            // add position data attribute
+            contentEl.dataset.position = _position.toString();
+        },
+        { flush: "sync" },
+    );
 
     onMounted(() => {
         contentEl = unrefElement(contentRef);

--- a/packages/oruga/src/composables/usePopoverAPI.ts
+++ b/packages/oruga/src/composables/usePopoverAPI.ts
@@ -4,6 +4,7 @@ import {
     watch,
     isRef,
     toValue,
+    watchEffect,
     type MaybeRefOrGetter,
     type WatchSource,
 } from "vue";
@@ -26,7 +27,7 @@ export type PopoverAPIOptions = {
      * In addition `centered` center the content in the middle of the screen.
      * @default 'top'
      */
-    position?: "centered" | PopoverPosition;
+    position?: MaybeRefOrGetter<"centered" | PopoverPosition>;
     /** Reference or getter resolving to the target element. */
     targetRef: MaybeRefOrGetter<EventTarget>;
     /** Reference or getter resolving to the popover content element. */
@@ -144,16 +145,14 @@ export function usePopoverAPI(options: PopoverAPIOptions): {
             // prevent default click event when is button
             event.preventDefault();
 
-        // open popover
-        open();
+        open(); // open popover
     }
 
     function onTriggerKeydown(event: KeyboardEvent): void {
         if (event.code !== "Enter" && event.code !== "Space") return;
         event.preventDefault();
 
-        // open popover
-        open();
+        open(); // open popover
     }
 
     // add event listener on trigger element
@@ -167,6 +166,28 @@ export function usePopoverAPI(options: PopoverAPIOptions): {
         useEventListener(contentRef, "toggle", options.onToggle);
     if (typeof options.onBeforeToggle === "function")
         useEventListener(contentRef, "beforetoggle", options.onBeforeToggle);
+
+    // apply position
+    watchEffect(() => {
+        contentEl = unrefElement(contentRef);
+        if (!contentEl) return;
+
+        const _position = toValue(position);
+
+        // add content position styles
+        contentEl.style.positionArea =
+            _position === "centered"
+                ? "none"
+                : Array.isArray(_position)
+                  ? _position.join(" ")
+                  : _position;
+
+        contentEl.style.positionTryFallbacks =
+            "flip-block, flip-inline, flip-block flip-inline";
+
+        // add position data attribute
+        contentEl.dataset.position = _position.toString();
+    });
 
     onMounted(() => {
         contentEl = unrefElement(contentRef);
@@ -195,19 +216,6 @@ export function usePopoverAPI(options: PopoverAPIOptions): {
 
         // place popover attribute on content
         contentEl.popover = behavior;
-
-        // add content position styles
-        contentEl.style.positionArea =
-            position === "centered"
-                ? "none"
-                : Array.isArray(position)
-                  ? position.join(" ")
-                  : position;
-        contentEl.style.positionTryFallbacks =
-            "flip-block, flip-inline, flip-block flip-inline";
-
-        // add position data attribute
-        contentEl.dataset.position = position.toString();
 
         if (targetTrigger && behavior !== "manual") {
             // get content id


### PR DESCRIPTION
## Proposed Changes

- When the position of a Popover API-based component changes during its lifetime, the updated position is not applied correctly. This occurs, for example, when the modal view is displayed instead of the normal positioning.
