### PR TITLE
feat(upload): add `before` and `after` slots

### DIFF
--- a/packages/docs/pages/components/Upload.md
+++ b/packages/docs/pages/components/Upload.md
@@ -55,9 +55,11 @@ Use it with the [Field](/components/Field) component to access all the functiona
 
 ### Slots
 
-| Name    | Description     | Bindings                                                                            |
-| ------- | --------------- | ----------------------------------------------------------------------------------- |
-| default | Default content | **onclick** `(event: Event): void` - click handler, only needed if a button is used |
+| Name    | Description                         | Bindings                                                                            |
+| ------- | ----------------------------------- | ----------------------------------------------------------------------------------- |
+| before  | Additional slot before the dragzone |                                                                                     |
+| default | Default content                     | **onclick** `(event: Event): void` - click handler, only needed if a button is used |
+| after   | Additional slot after the dragzone  |                                                                                     |
 
 </section>
 

--- a/packages/oruga/src/components/upload/Upload.vue
+++ b/packages/oruga/src/components/upload/Upload.vue
@@ -73,6 +73,10 @@ defineSlots<{
      * @param onclick {(event: Event): void} - click handler, only needed if a button is used
      */
     default?(props: { onclick: (event: Event) => void }): void;
+    /** Additional slot before the dragzone */
+    before?(): void;
+    /** Additional slot after the dragzone */
+    after?(): void;
 }>();
 
 const inputRef = useTemplateRef("inputElement");
@@ -258,6 +262,8 @@ defineExpose({
 
 <template>
     <label data-oruga="upload" :class="rootClasses">
+        <slot name="before" />
+
         <template v-if="!dragDrop">
             <slot :onclick="onClick" />
         </template>
@@ -275,6 +281,8 @@ defineExpose({
             @drop.prevent="onFileChange">
             <slot :onclick="onClick" />
         </div>
+
+        <slot name="after" />
 
         <input
             v-bind="inputBind"


### PR DESCRIPTION
## Proposed Changes

- Add a  `before` and `after` slot to the OUpload component. 
