### PR TITLE
feat(dropdown): add `href` link support

### DIFF
--- a/packages/docs/pages/components/Dropdown.md
+++ b/packages/docs/pages/components/Dropdown.md
@@ -121,9 +121,13 @@ The overlay is implemented using the native [Popover API](https://developer.mozi
 | clickable | Item is clickable and emit an event                                                       | boolean                | -      | <code style='white-space: nowrap; padding: 0;'>true</code>    |
 | disabled  | Item is disabled                                                                          | boolean                | -      | <code style='white-space: nowrap; padding: 0;'>false</code>   |
 | hidden    | Define whether the item is visible or not                                                 | boolean                | -      | <code style='white-space: nowrap; padding: 0;'>false</code>   |
+| href      | Make the item a HTML anchor element with the URL that the hyperlink points to             | string                 | -      |                                                               |
 | label     | Item label, unnecessary when default slot is used                                         | string                 | -      |                                                               |
 | override  | Override existing theme classes completely                                                | boolean                | -      |                                                               |
+| rel       | The relationship of the linked URL as space-separated link types                          | string                 | -      |                                                               |
 | tag       | Dropdown item tag name                                                                    | DynamicComponent       | -      |                                                               |
+| target    | Where to display the linked URL, as the name for a browsing context                       | string                 | -      |                                                               |
+| title     | The native title property represents the title of the element                             | string                 | -      |                                                               |
 | value     | Item value (it will be used as the v-model of the wrapper component) - default is an uuid | string\|number\|object | -      | <code style='white-space: nowrap; padding: 0;'>useId()</code> |
 
 ### Events

--- a/packages/oruga/src/components/dropdown/DropdownItem.vue
+++ b/packages/oruga/src/components/dropdown/DropdownItem.vue
@@ -25,7 +25,11 @@ const props = withDefaults(defineProps<DropdownItemProps<T>>(), {
     disabled: false,
     clickable: true,
     hidden: false,
+    title: undefined,
     tag: undefined,
+    href: undefined,
+    rel: undefined,
+    target: undefined,
 });
 
 const emits = defineEmits<{
@@ -121,7 +125,7 @@ const rootClasses = defineClasses(
 
 <template>
     <component
-        :is="tag ?? parent.itemTag"
+        :is="href ? 'a' : (tag ?? parent.itemTag)"
         v-show="!isHidden"
         :id="`${parent.menuId}-${item.identifier}`"
         ref="rootElement"
@@ -130,6 +134,10 @@ const rootClasses = defineClasses(
         :class="rootClasses"
         :role="parent.selectable ? 'option' : 'menuitem'"
         tabindex="-1"
+        :title="title"
+        :href="href"
+        :rel="rel"
+        :target="target"
         :aria-selected="parent.selectable ? isSelected : undefined"
         :aria-hidden="isHidden"
         :aria-disabled="disabled"

--- a/packages/oruga/src/components/dropdown/examples/index.md
+++ b/packages/oruga/src/components/dropdown/examples/index.md
@@ -17,14 +17,17 @@ import OptionsArrayCode from "./options-array.vue?raw";
 import OptionsGrouped from "./options-grouped.vue";
 import OptionsGroupedCode from "./options-grouped.vue?raw";
 
-import Modal from "./modal.vue";
-import ModalCode from "./modal.vue?raw";
-
 import Selectable from "./selectable.vue";
 import SelectableCode from "./selectable.vue?raw";
 
 import Scrollable from "./scrollable.vue";
 import ScrollableCode from "./scrollable.vue?raw";
+
+import Links from "./links.vue";
+import LinksCode from "./links.vue?raw";
+
+import Modal from "./modal.vue";
+import ModalCode from "./modal.vue?raw";
 
 import Position from "./position.vue";
 import PositionCode from "./position.vue?raw";
@@ -102,6 +105,12 @@ By default only one option can be selected and the selected option will be refer
 When having to many options, consider adding the `scrollable` property, which allows the options container to remain at a fixed height. The `max-height` property can be used to define the max container height.
 
 <ExampleViewer :component="Scrollable" :code="ScrollableCode" />
+
+### Links
+
+The menu can also consists of a list of links by using the `href` attribute for an option item.
+
+<ExampleViewer :component="Links" :code="LinksCode" />
 
 ### Modal
 

--- a/packages/oruga/src/components/dropdown/examples/links.vue
+++ b/packages/oruga/src/components/dropdown/examples/links.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import type { DropdownOptions } from "@oruga-ui/oruga-next";
+
+const options: DropdownOptions<string> = [
+    {
+        label: "Google",
+        value: "google",
+        href: "https://google.com",
+        target: "_blank",
+    },
+    {
+        label: "Yahoo",
+        value: "yahoo",
+        href: "https://yahoo.com",
+        target: "_blank",
+    },
+    {
+        label: "DuckDuckGo ",
+        value: "duckduckgo",
+        href: "https://duckduckgo.com",
+        target: "_blank",
+    },
+    {
+        label: "Bind",
+        value: "bing",
+        href: "https://bing.com",
+        target: "_blank",
+    },
+];
+</script>
+
+<template>
+    <section>
+        <o-dropdown :options="options" aria-label="search engine menu">
+            <template #trigger="{ active }">
+                <o-button
+                    variant="primary"
+                    label="Open Menu!"
+                    :icon-right="active ? 'caret-up' : 'caret-down'" />
+            </template>
+        </o-dropdown>
+    </section>
+</template>

--- a/packages/oruga/src/components/dropdown/props.ts
+++ b/packages/oruga/src/components/dropdown/props.ts
@@ -135,6 +135,11 @@ export type DropdownItemProps<T> = {
     value?: T;
     /** Item label, unnecessary when default slot is used */
     label?: string;
+    /**
+     * The native title property represents the title of the element
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/title
+     */
+    title?: string;
     /** Item is disabled */
     disabled?: boolean;
     /** Item is clickable and emit an event */
@@ -143,6 +148,21 @@ export type DropdownItemProps<T> = {
     hidden?: boolean;
     /** Dropdown item tag name */
     tag?: DynamicComponent;
+    /**
+     * Make the item a HTML anchor element with the URL that the hyperlink points to
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#href
+     */
+    href?: string;
+    /**
+     * The relationship of the linked URL as space-separated link types
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel
+     */
+    rel?: string;
+    /**
+     * Where to display the linked URL, as the name for a browsing context
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#target
+     */
+    target?: string;
 } & DropdownItemClasses;
 
 // class props (will not be displayed in the docs)

--- a/packages/oruga/src/components/dropdown/tests/dropdown.axe.test.ts
+++ b/packages/oruga/src/components/dropdown/tests/dropdown.axe.test.ts
@@ -85,6 +85,20 @@ describe("ODropdown a11y tests", () => {
             title: "axe dropdown - teleport",
             props: { options, teleport: true, label: "Trigger" },
         },
+        {
+            title: "axe dropdown - href lunkjt",
+            props: {
+                options: [
+                    ...options,
+                    {
+                        label: "Item 10",
+                        value: 10,
+                        href: "google.com",
+                        target: "_blank",
+                    },
+                ],
+            },
+        },
     ];
 
     test.each(a11yCases)("$title", async ({ props }) => {

--- a/packages/oruga/src/components/dropdown/tests/dropdown.axe.test.ts
+++ b/packages/oruga/src/components/dropdown/tests/dropdown.axe.test.ts
@@ -86,7 +86,7 @@ describe("ODropdown a11y tests", () => {
             props: { options, teleport: true, label: "Trigger" },
         },
         {
-            title: "axe dropdown - href lunkjt",
+            title: "axe dropdown - href",
             props: {
                 options: [
                     ...options,

--- a/packages/oruga/src/components/dropdown/tests/dropdown.unit.test.ts
+++ b/packages/oruga/src/components/dropdown/tests/dropdown.unit.test.ts
@@ -752,7 +752,12 @@ describe("ODropdown tests", () => {
                 { label: "Silver", value: "silver", disabled: true },
                 { label: "Vane", value: "vane" },
                 { label: "Zero", value: 0 },
-                { label: "One", value: 1 },
+                {
+                    label: "One",
+                    value: 1,
+                    href: "google.com",
+                    target: "_blank",
+                },
                 { label: "Two", value: 2, disabled: true },
             ];
 


### PR DESCRIPTION
## Proposed Changes

- Add native link href props to the ODropdownItem to make it more easy to display a list of links.