### PR TITLE
fix(tree): collapse items on click when not selectable

### DIFF
--- a/packages/oruga/src/components/tree/TreeItem.vue
+++ b/packages/oruga/src/components/tree/TreeItem.vue
@@ -163,7 +163,7 @@ const itemIconSize = computed(() => props.iconSize ?? parent.value.iconSize);
 
 /** Click listener, toggle the selection of the item. */
 function clickItem(event: Event): void {
-    if (hasToggleIcon.value) {
+    if (hasToggleIcon.value && isSelectable.value) {
         const toggleIcon = (event.target as HTMLElement).closest(
             "[data-toggle]",
         );

--- a/packages/oruga/src/components/tree/examples/index.md
+++ b/packages/oruga/src/components/tree/examples/index.md
@@ -91,6 +91,8 @@ You can enable multi-select with the `multiple` property. In multi-select trees,
 
 When having to many options, consider adding a max height using the `scrollHeight` property, which allows to cap the tree at a fixed `max-height`. This will render a long tree of options with a scrollbar. The component will emit a `scroll-start` or `scroll-end` event, when the top or bottom of the tree is reached.
 
+A group can be forced to stay open by setting `collapsable="false"`.
+
 <ExampleViewer :component="Scrollable" :code="ScrollableCode" />
 
 ### Empty

--- a/packages/oruga/src/components/tree/tests/tree.unit.test.ts
+++ b/packages/oruga/src/components/tree/tests/tree.unit.test.ts
@@ -559,6 +559,8 @@ describe("OTree tests", () => {
                 key: "Right",
             });
             expect(items[6].emitted("open")).toBeDefined();
+            // first child of Events should become visible after expand
+            expect(items[7].attributes("aria-hidden")).toBe("false");
             // Events element is still focused
             expect(items[6].attributes("tabindex")).toBe("0");
             expect(items[6].classes("o-tree__item--focused")).toBeTruthy();
@@ -627,24 +629,38 @@ describe("OTree tests", () => {
         });
 
         test("react accordingly when item is clicked without selectable", async () => {
+            const optionsWithChildren: TreeOptions<string> = [
+                {
+                    label: "Documents",
+                    options: [
+                        { label: "Work", value: "work" },
+                        { label: "Home", value: "home" },
+                    ],
+                },
+                { label: "Events", value: "events" },
+            ];
+
             const wrapper = mount(OTree, {
                 props: {
-                    options,
+                    options: optionsWithChildren,
+                    toggleIcon: "chevron",
                     selectable: false,
                 },
             });
 
-            const itemComps =
-                wrapper.findAllComponents<ComponentPublicInstance>(
-                    '[data-oruga="tree-item"]',
-                );
-            expect(itemComps.length).toBe(options.length);
+            const items = wrapper.findAll('[role="treeitem"]');
+            expect(items.length).toBe(4);
+            expect(items[0].attributes("aria-hidden")).toBe("false");
+            expect(items[1].attributes("aria-hidden")).toBe("true");
+            expect(items[2].attributes("aria-hidden")).toBe("true");
 
-            const treeItems = wrapper.findAll('[role="treeitem"]');
-            expect(treeItems.length).toBe(options.length);
+            const itemLabel = items[0].find(".o-tree__item-label");
+            expect(itemLabel.exists()).toBeTruthy();
+            await itemLabel.trigger("click");
 
-            await treeItems[0].trigger("click");
-            await treeItems[1].trigger("click");
+            expect(items[1].attributes("aria-hidden")).toBe("false");
+            expect(items[2].attributes("aria-hidden")).toBe("false");
+            expect(items[3].attributes("aria-hidden")).toBe("false");
             expect(wrapper.emitted("update:modelValue")).toBeUndefined();
         });
 


### PR DESCRIPTION
## Proposed Changes

- Correctly toggle collapse state of the OTreeItem component when the item is not selectable. Otherwise when selectable, the item gets selected an the collapse  state is only toggleable with the chevron icon.