### PR TITLE
fix(datepicker|timepicker): prevent popover closing input on blur event without change

### DIFF
--- a/packages/oruga/src/components/datepicker/tests/datepicker.unit.test.ts
+++ b/packages/oruga/src/components/datepicker/tests/datepicker.unit.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { mount, enableAutoUnmount } from "@vue/test-utils";
+import { nextTick } from "vue";
 
 import ODatepicker from "@/components/datepicker/Datepicker.vue";
 
@@ -80,6 +81,27 @@ describe("ODatepicker", () => {
         emits = wrapper.emitted("update:modelValue");
         expect(emits).toHaveLength(1);
         expect(input.element.value).toBe("");
+    });
+
+    test("keeps the overlay open when navigating a populated picker after input blur", async () => {
+        const wrapper = mount(ODatepicker, {
+            props: { modelValue: new Date(2024, 0, 1), active: true },
+        });
+
+        expect(
+            wrapper.find(".o-datepicker__content--active").exists(),
+        ).toBeTruthy();
+
+        const monthSelect = wrapper.find<HTMLSelectElement>(
+            'select[aria-label="Select Month"]',
+        );
+        monthSelect.element.focus();
+        await nextTick();
+        await monthSelect.setValue(1);
+
+        expect(
+            wrapper.find(".o-datepicker__content--active").exists(),
+        ).toBeTruthy();
     });
 
     test("react accordingly when an date is selected with multiple prop", async () => {

--- a/packages/oruga/src/components/utils/PickerInput.vue
+++ b/packages/oruga/src/components/utils/PickerInput.vue
@@ -13,6 +13,7 @@ import OInput from "../input/Input.vue";
 import {
     checkMinMaxDate,
     isDefined,
+    isEqual,
     isMobileAgent,
     isTrueish,
 } from "@/utils/helpers";
@@ -214,8 +215,9 @@ function setValue(value: string): void {
             (inputValue.value = props.formatter(date, isMobileNative.value)),
     );
 
-    // update the prop value
-    emits("update:value", date);
+    if (!isEqual(props.value, date))
+        // update the prop value
+        emits("update:value", date);
 }
 
 /** Get the value from html element behind the event and update the external value. */

--- a/packages/oruga/src/utils/helpers.ts
+++ b/packages/oruga/src/utils/helpers.ts
@@ -196,6 +196,9 @@ export function isEqual(valueA: unknown, valueB: unknown): boolean {
 
     // Check if both values are objecs.
     if (isObject(valueA) && isObject(valueB)) {
+        if (isDate(valueA) && isDate(valueB))
+            return valueA.getTime() === valueB.getTime();
+
         // Get the keys of both objects.
         const keys1 = Object.keys(valueA);
         const keys2 = Object.keys(valueB);


### PR DESCRIPTION
Fixes #1736

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Check whether the date value has changed before emitting an update event in the internal InputPicker component. This prevents the watcher from being triggered unnecessarily.
