### PR TITLE
fix(datepicker|timepicker): do not close on popover interaction

### DIFF
--- a/packages/oruga/src/components/datepicker/tests/datepicker.unit.test.ts
+++ b/packages/oruga/src/components/datepicker/tests/datepicker.unit.test.ts
@@ -104,6 +104,46 @@ describe("ODatepicker", () => {
         ).toBeTruthy();
     });
 
+    test("keeps the overlay open on first interaction when clicking a nav button in a populated picker", async () => {
+        vi.useFakeTimers();
+
+        const wrapper = mount(ODatepicker, {
+            props: { modelValue: new Date(2024, 0, 1) },
+        });
+
+        // picker is initially closed
+        expect(
+            wrapper.find(".o-datepicker__content--active").exists(),
+        ).toBeFalsy();
+
+        // focus the input to open the picker via openOnFocus
+        const input = wrapper.find("input");
+        await input.trigger("focus");
+
+        // advance past the 250ms openOnFocus delay
+        vi.advanceTimersByTime(300);
+        await nextTick();
+
+        // picker should now be open
+        expect(
+            wrapper.find(".o-datepicker__content--active").exists(),
+        ).toBeTruthy();
+
+        // blur the input (simulates focus moving away when clicking the nav button)
+        await input.trigger("blur");
+        await nextTick();
+
+        // click the previous month navigation button
+        const prevButton = wrapper.find(".o-datepicker__header__previous");
+        await prevButton.trigger("click");
+        await nextTick();
+
+        // picker should remain open after navigating months
+        expect(
+            wrapper.find(".o-datepicker__content--active").exists(),
+        ).toBeTruthy();
+    });
+
     test("react accordingly when an date is selected with multiple prop", async () => {
         const wrapper = mount(ODatepicker, {
             props: { modelValue: [new Date()], multiple: true },

--- a/packages/oruga/src/components/utils/PickerInput.vue
+++ b/packages/oruga/src/components/utils/PickerInput.vue
@@ -242,7 +242,10 @@ function onFocus(event: Event): void {
 }
 
 function onBlur(event: Event): void {
-    setEventValue(event);
+    const target = (event as FocusEvent).relatedTarget as Node | null;
+    if (!target || !contentRef.value?.contains(target)) {
+        setEventValue(event);
+    }
     emits("blur", event);
 }
 

--- a/packages/oruga/src/components/utils/PickerInput.vue
+++ b/packages/oruga/src/components/utils/PickerInput.vue
@@ -13,7 +13,6 @@ import OInput from "../input/Input.vue";
 import {
     checkMinMaxDate,
     isDefined,
-    isEqual,
     isMobileAgent,
     isTrueish,
 } from "@/utils/helpers";
@@ -215,8 +214,11 @@ function setValue(value: string): void {
             (inputValue.value = props.formatter(date, isMobileNative.value)),
     );
 
-    if (!isEqual(props.value, date))
-        // update the prop value
+    // Compare by formatted string: if the input value is identical to what the
+    // current prop formats to, nothing changed from the UI's perspective.
+    // This avoids false emits when the prop value has a time component that
+    // the formatter strips, which would make an isEqual(Date, Date) check fail.
+    if (props.formatter(props.value, isMobileNative.value) !== value)
         emits("update:value", date);
 }
 
@@ -242,10 +244,7 @@ function onFocus(event: Event): void {
 }
 
 function onBlur(event: Event): void {
-    const target = (event as FocusEvent).relatedTarget as Node | null;
-    if (!target || !contentRef.value?.contains(target)) {
-        setEventValue(event);
-    }
+    setEventValue(event);
     emits("blur", event);
 }
 


### PR DESCRIPTION
Fixes #1741 

## Proposed Changes

- Prevent updating the input value and closing the popover on input blur when the next focused element is inside the popover.