### PR TITLE
fix(table): select correct pagination page number for the current-page

### DIFF
--- a/packages/oruga/src/components/table/TablePagination.vue
+++ b/packages/oruga/src/components/table/TablePagination.vue
@@ -54,7 +54,7 @@ function pageChanged(page: number): void {
             <o-pagination
                 v-if="paginated"
                 v-bind="$attrs"
-                :current="currentPage"
+                :model-value="currentPage"
                 @change="pageChanged" />
         </div>
     </div>

--- a/packages/oruga/src/components/table/tests/table.unit.test.ts
+++ b/packages/oruga/src/components/table/tests/table.unit.test.ts
@@ -865,6 +865,31 @@ describe("OTable tests", () => {
             );
         });
 
+        test("highlights the current page when current page is updated", async () => {
+            const perPage = 3;
+
+            const wrapper = mount(OTable, {
+                props: {
+                    columns: [{ label: "ID", field: "id" }],
+                    paginated: true,
+                    data,
+                    perPage,
+                },
+            });
+            await nextTick();
+
+            await wrapper.setProps({ currentPage: 2 });
+
+            expect(
+                wrapper.findAll("tbody tr").map((row) => row.text()),
+            ).toEqual(
+                data.slice(perPage, perPage * 2).map((row) => String(row.id)),
+            );
+            expect(wrapper.find(".o-pagination__button--current").text()).toBe(
+                "2",
+            );
+        });
+
         test("show correct amount of rows when per page is set to 5", async () => {
             const perPage = 5;
 


### PR DESCRIPTION
<!-- Thank you for helping Oruga! -->

Fixes #1743 

<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- Correct missed OPagination `current` to `modelValue` change in Table pagination.